### PR TITLE
Implement deploy_dir_path (configuration)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -64,7 +64,6 @@ bundle exec routes:oas:editor
 # default setting
 R2OAS.configure do |config|
   config.version                            = :v3
-  #「docs」という名前は使えません。予約語です。
   config.root_dir_path                      = "./oas_docs"
   config.schema_save_dir_name               = "src"
   config.doc_save_file_name                 = "oas_doc.yml"
@@ -72,6 +71,9 @@ R2OAS.configure do |config|
   config.use_tag_namespace                  = true
   config.use_schema_namespace               = false
   config.interval_to_save_edited_tmp_schema = 15
+  # :dot or :underbar
+  config.namespace_type = :underbar
+  config.deploy_dir_path = "./deploy_docs"
 
   config.server.data = [
     {
@@ -132,9 +134,6 @@ R2OAS.configure do |config|
     paths_stats.heading_color                  = :yellow
     paths_stats.highlight_color                = :magenta
   end
-
-  # :dot or :underbar
-  config.namespace_type = :underbar
 end
 ```
 
@@ -249,6 +248,7 @@ $ bundle exec rake routes:oas:paths_stats
 |http_statuses_when_http_method|HTTPメソッド毎にどのHTTPステータスのレスポンスを用意するかを決める設定|omission...|
 |http_methods_when_generate_request_body|リクエストボディーを生成する時のHTTPメソッド|`[post put patch]`|
 |namespace_type|components/{schemas,requestBodies,...}名で使用する擬似ネームスペースの種類(:dot or :underbar)| `:underbar` |
+|deploy_dir_path|deployのディレクトリパス|`"./deploy_docs"`|
 
 #### server
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ In your rails project, Write `config/environments/development.rb` like that:
 # default setting
 R2OAS.configure do |config|
   config.version                            = :v3
-  #「docs」is not used. 「docs」is reserved word
   config.root_dir_path                      = "./oas_docs"
   config.schema_save_dir_name               = "src"
   config.doc_save_file_name                 = "oas_doc.yml"
@@ -80,6 +79,9 @@ R2OAS.configure do |config|
   config.use_tag_namespace                  = true
   config.use_schema_namespace               = false
   config.interval_to_save_edited_tmp_schema = 15
+  # :dot or :underbar
+  config.namespace_type = :underbar
+  config.deploy_dir_path = "./deploy_docs"
 
   config.server.data = [
     {
@@ -140,9 +142,6 @@ R2OAS.configure do |config|
     paths_stats.heading_color                  = :yellow
     paths_stats.highlight_color                = :magenta
   end
-
-  # :dot or :underbar
-  config.namespace_type = :underbar
 end
 ```
 
@@ -248,6 +247,7 @@ we explain the options that can be set.
 |http_statuses_when_http_method|Determine the response to support for each HTTP method|omission...|
 |http_methods_when_generate_request_body|HTTP methods when generate requestBody|`[post put patch]`|
 |namespace_type|namespace for components(schemas/requestBodies) name| `underbar` |
+|deploy_dir_path|deploy directory.|`"./deploy_docs"`|
 
 #### server
 

--- a/lib/r2-oas/app_configuration.rb
+++ b/lib/r2-oas/app_configuration.rb
@@ -44,6 +44,7 @@ module R2OAS
     DEFAULT_TOOL = Tool.new
     # :dot or :underbar
     DEFAULT_NAMESPACE_TYPE = :underbar
+    DEFAULT_DEPLOY_DIR_PATH = "./deploy_docs"
 
     PUBLIC_VALID_OPTIONS_KEYS = %i[
       version
@@ -60,6 +61,7 @@ module R2OAS
       http_methods_when_generate_request_body
       tool
       namespace_type
+      deploy_dir_path
     ].freeze
 
     UNPUBLIC_VALID_OPTIONS_KEYS = %i[
@@ -94,6 +96,7 @@ module R2OAS
       target.tool                                    = DEFAULT_TOOL
       target.http_methods_when_generate_request_body = DEFAULT_HTTP_METHODS_WHEN_GENERATE_REQUEST_BODY
       target.namespace_type                          = DEFAULT_NAMESPACE_TYPE
+      target.deploy_dir_path                         = DEFAULT_DEPLOY_DIR_PATH
     end
   end
 end

--- a/lib/r2-oas/deploy/client.rb
+++ b/lib/r2-oas/deploy/client.rb
@@ -15,7 +15,7 @@ module R2OAS
       private
 
       def copy_swagger_ui_dist
-        docs_path = File.expand_path(Rails.root.join('docs'), __FILE__)
+        docs_path = File.expand_path(Rails.root.join(deploy_dir_path), __FILE__)
         return if FileTest.exists?(docs_path)
 
         FileUtils.mkdir_p(docs_path) unless FileTest.exists?(docs_path)
@@ -25,9 +25,7 @@ module R2OAS
       end
 
       def copy_swagger_ui_index
-        index_path = File.expand_path("#{Rails.root.join('docs')}/index.html", __FILE__)
-        raise 'Exist docs already' if FileTest.exists?(index_path)
-
+        index_path = File.expand_path(Rails.root.join(deploy_dir_path, "index.html"), __FILE__)
         @schema_file_path = doc_save_file_name
         template_path = File.expand_path('swagger-ui/index.html.erb', __dir__)
         template = File.read(template_path)
@@ -36,7 +34,7 @@ module R2OAS
       end
 
       def copy_oas_doc_file
-        swagger_file_path = File.expand_path(Rails.root.join('docs', doc_save_file_name), __FILE__)
+        swagger_file_path = File.expand_path(Rails.root.join(deploy_dir_path, doc_save_file_name), __FILE__)
         oas_doc_file_path = File.expand_path("#{root_dir_path}/#{doc_save_file_name}")
         FileUtils.cp_r(oas_doc_file_path, swagger_file_path)
       end

--- a/spec/dummy_app/application.rb
+++ b/spec/dummy_app/application.rb
@@ -16,6 +16,7 @@ module DummyApp
 
     R2OAS.configure do |c|
       c.root_dir_path = "#{config.root}/oas_docs"
+      c.deploy_dir_path = "#{config.root}/deploy_docs"
     end
   end
 end

--- a/spec/r2-oas/configuration_spec.rb
+++ b/spec/r2-oas/configuration_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe R2OAS::Configuration do
         expect(subject[:use_tag_namespace]).to eq true
         expect(subject[:use_schema_namespace]).to eq true
         expect(subject[:namespace_type]).to eq :underbar
+        expect(subject[:deploy_dir_path]).to eq "./deploy_docs"
         expect(subject[:http_statuses_when_http_method][:get][:default]).to include('200', '422')
         expect(subject[:http_statuses_when_http_method][:get][:path_parameter]).to include('200', '404', '422')
         expect(subject[:http_statuses_when_http_method][:post][:default]).to include('201', '422')
@@ -86,6 +87,7 @@ RSpec.describe R2OAS::Configuration do
             config.use_tag_namespace = true
             config.use_schema_namespace = true
             config.namespace_type = :dot
+            config.deploy_dir_path = "dist_docs"
             config.http_statuses_when_http_method = {
               get: {
                 default: %w[200 403],
@@ -162,6 +164,7 @@ RSpec.describe R2OAS::Configuration do
         expect(subject[:use_tag_namespace]).to eq true
         expect(subject[:use_schema_namespace]).to eq true
         expect(subject[:namespace_type]).to eq :dot
+        expect(subject[:deploy_dir_path]).to eq "dist_docs"
         expect(subject[:http_statuses_when_http_method][:get][:default]).to include('200', '403')
         expect(subject[:http_statuses_when_http_method][:get][:path_parameter]).to include('200', '404', '403')
         expect(subject[:http_statuses_when_http_method][:post][:default]).to include('201', '403')

--- a/spec/r2-oas/deploy/client_spec.rb
+++ b/spec/r2-oas/deploy/client_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+require 'r2-oas/deploy/client'
+
+RSpec.describe R2OAS::Deploy::Client do
+  let(:client) { described_class.new }
+
+  describe '#deploy' do
+    before do
+      create_dot_paths
+      generate_docs
+      client.deploy
+    end
+
+    after do
+      delete_oas_docs
+      delete_deploy_docs
+    end
+
+    it do
+      expect(FileTest.exists?(deploy_dir_path)).to eq true
+      expect(FileTest.exists?("#{deploy_dir_path}/index.html")).to eq true
+      expect(FileTest.exists?("#{deploy_dir_path}/dist")).to eq true 
+    end
+  end
+end

--- a/spec/r2-oas/tasks/tool_spec.rb
+++ b/spec/r2-oas/tasks/tool_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe 'tool_rake' do
 
   after do
     delete_oas_docs
-    delete_docs_for_deploy
+    delete_deploy_docs
   end
 
   describe 'routes:oas:deploy' do
@@ -21,8 +21,8 @@ RSpec.describe 'tool_rake' do
     end
 
     it do
-      expect(FileTest.exists?("#{Rails.root}/docs")).to eq true
-      expect(FileTest.exists?("#{Rails.root}/docs/#{doc_save_file_name}")).to eq true
+      expect(FileTest.exists?("#{deploy_dir_path}")).to eq true
+      expect(FileTest.exists?("#{deploy_dir_path}/#{doc_save_file_name}")).to eq true
     end
   end
 

--- a/spec/support/helpers/create_helper.rb
+++ b/spec/support/helpers/create_helper.rb
@@ -18,8 +18,8 @@ module CreateHelper
     FileUtils.rm_rf Rails.root.join(root_dir_path)
   end
 
-  def delete_docs_for_deploy
-    FileUtils.rm_rf Rails.root.join('docs')
+  def delete_deploy_docs
+    FileUtils.rm_rf Rails.root.join(deploy_dir_path)
   end
 
   def create_components_securitySchemes_file

--- a/spec/support/helpers/path_helper.rb
+++ b/spec/support/helpers/path_helper.rb
@@ -13,6 +13,10 @@ module PathHelper
     R2OAS.doc_save_file_name
   end
 
+  def deploy_dir_path
+    R2OAS.deploy_dir_path
+  end
+
   def dot_paths_path
     "#{root_dir_path}/.paths"
   end


### PR DESCRIPTION
### Summary

Implement deploy_dir_path options

```ruby
R2OAS.configure do |config|
  config.deploy_dir_path = "./deploy_docs"
end
```