### PR TITLE
Do not generate component schema when 204 and 404 (default)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/yukihirop/r2-oas/badge.svg)](https://coveralls.io/github/yukihirop/r2-oas)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f8c3846f350bb412fd63/maintainability)](https://codeclimate.com/github/yukihirop/r2-oas/maintainability)
 
-railsのルーティング情報からOpenAPI形式のドキュメントを生成し、閲覧・編集・管理するためのrakeタスクの提供をします。
+Railsのルーティング情報からOpenAPI形式のドキュメントを生成し、閲覧・編集・管理するためのrakeタスクの提供をします。
 
 ```bash
 bundle exec rake routes:oas:docs    # ドキュメント生成

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/yukihirop/r2-oas/badge.svg)](https://coveralls.io/github/yukihirop/r2-oas)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f8c3846f350bb412fd63/maintainability)](https://codeclimate.com/github/yukihirop/r2-oas/maintainability)
 
-Generate api docment(OpenAPI) side only from `rails` routing.
+Generate api docment(OpenAPI) side only from `Rails` routing.
 
 Provides a rake command to help `generate` , `view` , and `edit` OpenAPI documents.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/github/yukihirop/r2-oas/badge.svg)](https://coveralls.io/github/yukihirop/r2-oas)
 [![Maintainability](https://api.codeclimate.com/v1/badges/f8c3846f350bb412fd63/maintainability)](https://codeclimate.com/github/yukihirop/r2-oas/maintainability)
 
-Generate api docment(OpenAPI) side only from `rails` routing.
+Generate api docment(OpenAPI) side only from `Rails` routing.
 
 Provides a rake command to help `generate` , `view` , and `edit` OpenAPI documents.
 
@@ -134,6 +134,7 @@ R2OAS.configure do |config|
   }
 
   config.http_methods_when_generate_request_body = %w[post patch put]
+  config.ignored_http_statuses_when_generate_component_schema = %w[204 404]
 
   config.tool.paths_stats.configure do |paths_stats|
     paths_stats.month_to_turn_to_warning_color = 3
@@ -179,21 +180,6 @@ $ bundle exec rake routes:oas:paths_ls
 $ bundle exec rake routes:oas:paths_stats
 ```
 
-## 📚 More Usage
-
-- [How to generate docs](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_GENERATE_DOCS.md)
-- [How to start swagger editor](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_START_SWAGGER_EDITOR.md)
-- [How to start swagger ui](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_START_SWAGGER_UI.md)
-- [How to monitor swagger document](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_MONITOR_SWAGGER_DOC.md)
-- [How to analyze docs](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_ANALYZE_DOCS.md)
-- [How to clean docs](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_CLEAN_DOCS.md)
-- [How to deploy swagger doc](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_DEPLOY_SWAGGER_DOC.md)
-- [How to use tag namespace](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_USE_TAG_NAMESPACE.md)
-- [How to use schema namespace](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_USE_SCHEMA_NAMESPACE.md)
-- [How to use hook when generate doc](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_USE_HOOK_WHEN_GENERATE_DOC.md)
-- [How to display paths list](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_DISPLAY_PATHS_LIST.md)
-- [How to display paths stats](https://github.com/yukihirop/r2-oas/blob/master/docs/HOW_TO_DISPLAY_PATHS_STATS.md)
-
 ## ❤️ Support Rails Version
 
 - Rails (>= 4.2.5.1)
@@ -206,12 +192,6 @@ $ bundle exec rake routes:oas:paths_stats
 
 - Rails Engine Routing
 - Rails Normal Routing
-
-## ❤️ Support OpenAPI Schema
-
-|version|document|
-|-------|--------|
-|v3|[versions/v3.md](https://github.com/yukihirop/r2-oas/blob/master/docs/versions/v3.md)|
 
 ## ❗️ Convention over Configuration (CoC)
 
@@ -246,6 +226,7 @@ we explain the options that can be set.
 |interval_to_save_edited_tmp_schema|Interval(sec) to save edited tmp schema|`15`|
 |http_statuses_when_http_method|Determine the response to support for each HTTP method|omission...|
 |http_methods_when_generate_request_body|HTTP methods when generate requestBody|`[post put patch]`|
+|ignored_http_statuses_when_generate_component_schema|Ignore HTTP statuses when generate component schema|`[204 404]`|
 |namespace_type|namespace for components(schemas/requestBodies) name| `underbar` |
 |deploy_dir_path|deploy directory.|`"./deploy_docs"`|
 
@@ -308,243 +289,6 @@ account.yml
 account.yml               # ignore
 account.yml               # ignore
 ```
-
-## 💊 Life Cycle Methods (Hook Metohds)
-
-Supported hook(life cycle methods) is like this:
-
-- `before_create`
-- `after_create`
-
-Supported Hook class is like this:
-
-- `R2OAS::Schema::V3::InfoObject`
-- `R2OAS::Schema::V3::PathsObject`
-- `R2OAS::Schema::V3::PathItemObject`
-- `R2OAS::Schema::V3::ExternalDocumentObject`
-- `R2OAS::Schema::V3::ComponentsObject`
-- `R2OAS::Schema::V3::Components::SchemaObject`
-- `R2OAS::Schema::V3::Components::RequestBodyObject`
-
-By inheriting these classes, you can hook them at the time of document generation by writing like this:
-
-#### case: InfoObject
-
-```ruby
-class CustomInfoObject < R2OAS::Schema::V3::InfoObject
-  before_create do |doc|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something .... 
-    })
-  end
-
-  after_create do |doc, path|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something ....
-    })
-  end
-end
-```
-
-#### case: PathsObject
-
-```ruby
-class CustomPathsObject < R2OAS::Schema::V3::PathsObject
-  before_create do |doc|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something .... 
-    })
-  end
-
-  after_create do |doc|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something ....
-    })
-  end
-end
-```
-
-#### case: PathItemObject
-
-```ruby
-class CustomPathItemObject < R2OAS::Schema::V3::PathItemObject
-  before_create do |doc, path|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something .... 
-    })
-  end
-
-  after_create do |doc, schema_name|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something ....
-    })
-  end
-end
-```
-
-#### case: ExternalDocumentObject
-
-```ruby
-class CustomExternalDocumentObject < R2OAS::Schema::V3::ExternalDocumentObject
-  before_create do |doc|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something .... 
-    })
-  end
-
-  after_create do |doc|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something ....
-    })
-  end
-end
-```
-
-#### case: ComponentsObject
-
-```ruby
-class CustomComponentsObject < R2OAS::Schema::V3::ComponentsObject
-  before_create do |doc|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something .... 
-    })
-  end
-
-  after_create do |doc|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something ....
-    })
-  end
-end
-```
-
-#### case: Components::SchemaObject
-
-```ruby
-class CustomComponentsSchemaObject < R2OAS::Schema::V3::Components::SchemaObject
-  before_create do |doc, schema_name|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something .... 
-    })
-  end
-
-  after_create do |doc, schema_name|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something ....
-    })
-  end
-end
-```
-
-If you want to determine the component schema name at runtime, like this:
-
-```ruby
-class CustomComponentsSchemaObject < R2OAS::Schema::V3::Components::SchemaObject
-  def components_schema_name(doc, path_component, tag_name, verb, http_status, schema_name)
-    # [Important] Please return string.
-    # default
-    schema_name
-  end
-end
-```
-
-`path_component` is `R2OAS::Routing::PathComponent` instance.
-
-```ruby
-module R2OAS
-  module Routing
-    class PathComponent < BaseComponent
-      def initialize(path)
-      def to_s
-      def symbol_to_brace
-      def path_parameters_data
-      def path_excluded_path_parameters
-      def exist_path_parameters?
-      def path_parameters
-      private
-      def without_format
-```
-
-#### case: Components::RequestBodyObject
-
-```ruby
-class CustomComponentsRequestBodyObject < R2OAS::Schema::V3::Components::RequestBodyObject
-  before_create do |doc, schema_name|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something .... 
-    })
-  end
-
-  after_create do |doc, schema_name|
-    # [Important] Please change doc destructively.
-    # [Important] To be able to use methods in Rails !
-    doc.merge!({
-      # Something ....
-    })
-  end
-end
-```
-
-If you want to determine the component schema name at runtime, like this:
-
-```ruby
-class CustomComponentsRequestBodyObject < R2OAS::Schema::V3::Components::RequestBodyObject
-  def components_request_body_name(doc, path_component, tag_name, verb, schema_name)
-    # [Important] Please return string.
-    # default
-    schema_name
-  end
-
-  def components_schema_name(doc, path_component, tag_name, verb, schema_name)
-    # [Important] Please return string.
-    # default
-    schema_name
-  end
-end
-```
-
-And write this to the configuration.
-
-```ruby
-# If only InfoObject and PathItemObject, use a custom class
-R2OAS.configure do |config|
-  # 
-  # omission ...
-  # 
-  config.use_object_classes.merge!({
-    info_object:      CustomInfoObject,
-    path_item_object: CustomPathItemObject
-  })
-end
-```
-
-This is the end.
 
 ## 🔩 CORS
 

--- a/docs/setting/configure.md
+++ b/docs/setting/configure.md
@@ -70,6 +70,7 @@ R2OAS.configure do |config|
   }
 
   config.http_methods_when_generate_request_body = %w[post patch put]
+  config.ignored_http_statuses_when_generate_component_schema = %w[204 404]
 
   config.tool.paths_stats.configure do |paths_stats|
     paths_stats.month_to_turn_to_warning_color = 3
@@ -97,6 +98,7 @@ we explain the options that can be set.
 |interval_to_save_edited_tmp_schema|Interval(sec) to save edited tmp schema|`15`|
 |http_statuses_when_http_method|Determine the response to support for each HTTP method|omission...|
 |http_methods_when_generate_request_body|HTTP methods when generate requestBody|`[post put patch]`|
+|ignored_http_statuses_when_generate_component_schema|Ignore HTTP statuses when generate component schema|`[204 404]`|
 |namespace_type|namespace for components(schemas/requestBodies) name| `underbar` |
 |deploy_dir_path|deploy directory.|`"./deploy_docs"`|
 

--- a/lib/r2-oas/app_configuration.rb
+++ b/lib/r2-oas/app_configuration.rb
@@ -45,7 +45,7 @@ module R2OAS
     DEFAULT_TOOL = Tool.new
     # :dot or :underbar
     DEFAULT_NAMESPACE_TYPE = :underbar
-    DEFAULT_DEPLOY_DIR_PATH = "./deploy_docs"
+    DEFAULT_DEPLOY_DIR_PATH = './deploy_docs'
 
     PUBLIC_VALID_OPTIONS_KEYS = %i[
       version

--- a/lib/r2-oas/app_configuration.rb
+++ b/lib/r2-oas/app_configuration.rb
@@ -40,6 +40,7 @@ module R2OAS
       }
     }
     DEFAULT_HTTP_METHODS_WHEN_GENERATE_REQUEST_BODY = %w[post patch put]
+    DEFAULT_IGNORED_HTTP_STATUSES_WHEN_GENERATE_COMPONENT_SCHEMA = %w[204 404]
     # rubocop:enable Style/MutableConstant
     DEFAULT_TOOL = Tool.new
     # :dot or :underbar
@@ -59,6 +60,7 @@ module R2OAS
       swagger
       http_statuses_when_http_method
       http_methods_when_generate_request_body
+      ignored_http_statuses_when_generate_component_schema
       tool
       namespace_type
       deploy_dir_path
@@ -82,21 +84,22 @@ module R2OAS
     private
 
     module_function def set_default(target)
-      target.version                                 = DEFAULT_VERSION
-      target.root_dir_path                           = DEFAULT_ROOT_DIR_PATH
-      target.schema_save_dir_name                    = DEFAULT_SCHEMA_SAVE_DIR_NAME
-      target.doc_save_file_name                      = DEFAULT_DOC_SAVE_FILE_NAME
-      target.force_update_schema                     = DEFAULT_FORCE_UPDATE_SCHEMA
-      target.use_tag_namespace                       = DEFAULT_USE_TAG_NAMESPACE
-      target.use_schema_namespace                    = DEFAULT_USE_SCHEMA_NAMESPACE
-      target.server                                  = DEFAULT_SERVER
-      target.interval_to_save_edited_tmp_schema      = DEFAULT_INTERVAL_TO_SAVE_EDITED_TMP_SCHEMA
-      target.swagger                                 = DEFAULT_SWAGGER
-      target.http_statuses_when_http_method          = DEFAULT_HTTP_STATUSES_WHEN_HTTP_METHOD
-      target.tool                                    = DEFAULT_TOOL
-      target.http_methods_when_generate_request_body = DEFAULT_HTTP_METHODS_WHEN_GENERATE_REQUEST_BODY
-      target.namespace_type                          = DEFAULT_NAMESPACE_TYPE
-      target.deploy_dir_path                         = DEFAULT_DEPLOY_DIR_PATH
+      target.version                                              = DEFAULT_VERSION
+      target.root_dir_path                                        = DEFAULT_ROOT_DIR_PATH
+      target.schema_save_dir_name                                 = DEFAULT_SCHEMA_SAVE_DIR_NAME
+      target.doc_save_file_name                                   = DEFAULT_DOC_SAVE_FILE_NAME
+      target.force_update_schema                                  = DEFAULT_FORCE_UPDATE_SCHEMA
+      target.use_tag_namespace                                    = DEFAULT_USE_TAG_NAMESPACE
+      target.use_schema_namespace                                 = DEFAULT_USE_SCHEMA_NAMESPACE
+      target.server                                               = DEFAULT_SERVER
+      target.interval_to_save_edited_tmp_schema                   = DEFAULT_INTERVAL_TO_SAVE_EDITED_TMP_SCHEMA
+      target.swagger                                              = DEFAULT_SWAGGER
+      target.http_statuses_when_http_method                       = DEFAULT_HTTP_STATUSES_WHEN_HTTP_METHOD
+      target.tool                                                 = DEFAULT_TOOL
+      target.http_methods_when_generate_request_body              = DEFAULT_HTTP_METHODS_WHEN_GENERATE_REQUEST_BODY
+      target.ignored_http_statuses_when_generate_component_schema = DEFAULT_IGNORED_HTTP_STATUSES_WHEN_GENERATE_COMPONENT_SCHEMA
+      target.namespace_type                                       = DEFAULT_NAMESPACE_TYPE
+      target.deploy_dir_path                                      = DEFAULT_DEPLOY_DIR_PATH
     end
   end
 end

--- a/lib/r2-oas/deploy/client.rb
+++ b/lib/r2-oas/deploy/client.rb
@@ -25,7 +25,7 @@ module R2OAS
       end
 
       def copy_swagger_ui_index
-        index_path = File.expand_path(Rails.root.join(deploy_dir_path, "index.html"), __FILE__)
+        index_path = File.expand_path(Rails.root.join(deploy_dir_path, 'index.html'), __FILE__)
         @schema_file_path = doc_save_file_name
         template_path = File.expand_path('swagger-ui/index.html.erb', __dir__)
         template = File.read(template_path)

--- a/lib/r2-oas/schema/v3/object/path_item_object.rb
+++ b/lib/r2-oas/schema/v3/object/path_item_object.rb
@@ -64,18 +64,26 @@ module R2OAS
 
         def responses_when_http_status
           http_statuses.each_with_object({}) do |http_status, result|
-            result.deep_merge!(
-              http_status => {
-                'description' => "#{@tag_name} description",
-                'content' => {
-                  'application/json' => {
-                    'schema' => {
-                      '$ref' => "#/components/schemas/#{_components_schema_name(http_status)}"
+            if (ignored_http_statuses_when_generate_component_schema.include?(http_status))
+              result.deep_merge!(
+                http_status => {
+                  'description' => "#{@tag_name} description"
+                }
+              )
+            else
+              result.deep_merge!(
+                http_status => {
+                  'description' => "#{@tag_name} description",
+                  'content' => {
+                    'application/json' => {
+                      'schema' => {
+                        '$ref' => "#/components/schemas/#{_components_schema_name(http_status)}"
+                      }
                     }
                   }
                 }
-              }
-            )
+              )
+            end
           end
         end
 

--- a/lib/r2-oas/schema/v3/object/path_item_object.rb
+++ b/lib/r2-oas/schema/v3/object/path_item_object.rb
@@ -64,7 +64,7 @@ module R2OAS
 
         def responses_when_http_status
           http_statuses.each_with_object({}) do |http_status, result|
-            if (ignored_http_statuses_when_generate_component_schema.include?(http_status))
+            if ignored_http_statuses_when_generate_component_schema.include?(http_status)
               result.deep_merge!(
                 http_status => {
                   'description' => "#{@tag_name} description"

--- a/r2-oas.gemspec
+++ b/r2-oas.gemspec
@@ -34,9 +34,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'terminal-table', '~> 1.6.0'
   spec.add_runtime_dependency 'watir', '~> 6.0'
   spec.add_development_dependency 'bundler', '~> 1.17'
+  spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
-  spec.add_development_dependency 'coveralls'
 end

--- a/r2-oas.gemspec
+++ b/r2-oas.gemspec
@@ -10,24 +10,10 @@ Gem::Specification.new do |spec|
   spec.authors       = ['yukihirop']
   spec.email         = ['te108186@gmail.com']
 
-  spec.summary       = 'Generate api docment(OpenAPI) side only from rails routing.'
-  spec.description   = <<~EOF
-    Generate api docment(OpenAPI) side only from `rails` routing.
-    Provides a rake command to help `generate` , `view` , and `edit` OpenAPI documents.
+  spec.summary       = 'Provide rake tasks to management API Docment (OpenAPI)'
+  spec.description   = "Let's intuitively write API documentation with Swagger Editor in your Rails Project! 😊"
 
-    ```
-    bundle exec rake routes:oas:docs    # generate
-    bundle exec rake routes:oas:ui      # view
-    bundle exec rake routes:oas:editor  # edit
-    bundle exec rake routes:oas:monitor # monitor
-    bundle exec rake routes:oas:dist    # distribute
-    bundle exec rake routes:oas:clean   # clean
-    bundle exec rake routes:oas:analyze # analyze
-    bundle exec rake routes:oas:deploy  # deploy
-    ```
-  EOF
-
-  spec.homepage      = 'https://github.com/yukihirop/r2-oas'
+  spec.homepage      = 'https://yukihirop.github.io/r2-oas'
   spec.license       = 'MIT'
 
   # Specify which files should be added to the gem when it is released.

--- a/spec/r2-oas/configuration_spec.rb
+++ b/spec/r2-oas/configuration_spec.rb
@@ -175,6 +175,7 @@ RSpec.describe R2OAS::Configuration do
         expect(subject[:http_statuses_when_http_method][:put][:path_parameter]).to include('204', '404', '403')
         expect(subject[:http_statuses_when_http_method][:delete][:default]).to include('200', '403')
         expect(subject[:http_statuses_when_http_method][:delete][:path_parameter]).to include('200', '404', '403')
+        expect(subject[:ignored_http_statuses_when_generate_component_schema]).to include('204', '404')
         # server configuration
         expect(subject[:server].data[0][:url]).to eq 'http://localhost:3000'
         expect(subject[:server].data[0][:description]).to eq 'main'

--- a/spec/r2-oas/configuration_spec.rb
+++ b/spec/r2-oas/configuration_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe R2OAS::Configuration do
         expect(subject[:use_tag_namespace]).to eq true
         expect(subject[:use_schema_namespace]).to eq true
         expect(subject[:namespace_type]).to eq :underbar
-        expect(subject[:deploy_dir_path]).to eq "./deploy_docs"
+        expect(subject[:deploy_dir_path]).to eq './deploy_docs'
         expect(subject[:http_statuses_when_http_method][:get][:default]).to include('200', '422')
         expect(subject[:http_statuses_when_http_method][:get][:path_parameter]).to include('200', '404', '422')
         expect(subject[:http_statuses_when_http_method][:post][:default]).to include('201', '422')
@@ -87,7 +87,7 @@ RSpec.describe R2OAS::Configuration do
             config.use_tag_namespace = true
             config.use_schema_namespace = true
             config.namespace_type = :dot
-            config.deploy_dir_path = "dist_docs"
+            config.deploy_dir_path = 'dist_docs'
             config.http_statuses_when_http_method = {
               get: {
                 default: %w[200 403],
@@ -164,7 +164,7 @@ RSpec.describe R2OAS::Configuration do
         expect(subject[:use_tag_namespace]).to eq true
         expect(subject[:use_schema_namespace]).to eq true
         expect(subject[:namespace_type]).to eq :dot
-        expect(subject[:deploy_dir_path]).to eq "dist_docs"
+        expect(subject[:deploy_dir_path]).to eq 'dist_docs'
         expect(subject[:http_statuses_when_http_method][:get][:default]).to include('200', '403')
         expect(subject[:http_statuses_when_http_method][:get][:path_parameter]).to include('200', '404', '403')
         expect(subject[:http_statuses_when_http_method][:post][:default]).to include('201', '403')

--- a/spec/r2-oas/deploy/client_spec.rb
+++ b/spec/r2-oas/deploy/client_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'r2-oas/deploy/client'
 
@@ -19,7 +21,7 @@ RSpec.describe R2OAS::Deploy::Client do
     it do
       expect(FileTest.exists?(deploy_dir_path)).to eq true
       expect(FileTest.exists?("#{deploy_dir_path}/index.html")).to eq true
-      expect(FileTest.exists?("#{deploy_dir_path}/dist")).to eq true 
+      expect(FileTest.exists?("#{deploy_dir_path}/dist")).to eq true
     end
   end
 end

--- a/spec/r2-oas/schema/v3/object/path_item_object_spec.rb
+++ b/spec/r2-oas/schema/v3/object/path_item_object_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe R2OAS::Schema::V3::PathItemObject do
           'description' => 'delete description',
           'responses' =>
           { '200' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Api_V1_Task' } } } },
-            '404' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Api_V1_Task' } } } },
+            '404' => { 'description' => 'api/v1/task description' },
             '422' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Api_V1_Task' } } } } },
           'deprecated' => false,
           'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] }

--- a/spec/r2-oas/schema/v3/object/paths_object_spec.rb
+++ b/spec/r2-oas/schema/v3/object/paths_object_spec.rb
@@ -74,8 +74,8 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
                 'summary' => 'patch summary',
                 'description' => 'patch description',
                 'responses' =>
-                { '204' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                  '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
+                { '204' => { 'description' => 'task description' },
+                  '404' => { 'description' => 'task description' },
                   '422' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
                 'deprecated' => false,
                 'requestBody' => { '$ref' => '#/components/requestBodies/Task' },
@@ -114,7 +114,7 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
                 'description' => 'delete description',
                 'responses' =>
                 { '200' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Api_V1_Task' } } } },
-                  '404' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Api_V1_Task' } } } },
+                  '404' => { 'description' => 'api/v1/task description' },
                   '422' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Api_V1_Task' } } } } },
                 'deprecated' => false,
                 'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] } }
@@ -149,8 +149,8 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
                 'summary' => 'patch summary',
                 'description' => 'patch description',
                 'responses' =>
-                { '204' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                  '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
+                { '204' => { 'description' => 'task description' },
+                  '404' => { 'description' => 'task description' },
                   '422' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
                 'deprecated' => false,
                 'requestBody' => { '$ref' => '#/components/requestBodies/Task' },
@@ -189,7 +189,7 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
                 'description' => 'delete description',
                 'responses' =>
                 { '200' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/api.v1.Task' } } } },
-                  '404' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/api.v1.Task' } } } },
+                  '404' => { 'description' => 'api/v1/task description' },
                   '422' => { 'description' => 'api/v1/task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/api.v1.Task' } } } } },
                 'deprecated' => false,
                 'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] } }
@@ -228,8 +228,8 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
               'summary' => 'patch summary',
               'description' => 'patch description',
               'responses' =>
-              { '204' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
+              { '204' => { 'description' => 'task description' },
+                '404' => { 'description' => 'task description' },
                 '422' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
               'deprecated' => false,
               'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] },
@@ -238,8 +238,8 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
               'summary' => 'put summary',
               'description' => 'put description',
               'responses' =>
-              { '204' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
+              { '204' => { 'description' => 'task description' },
+                '404' => { 'description' => 'task description' },
                 '422' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
               'deprecated' => false,
               'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] } }
@@ -316,7 +316,7 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
               'description' => 'get description',
               'responses' =>
               { '200' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
+                '404' => { 'description' => 'task description' } },
               'deprecated' => false,
               'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] } },
                                         '/tasks/{id}' =>
@@ -326,7 +326,7 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
               'description' => 'get description',
               'responses' =>
               { '200' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
+                '404' => { 'description' => 'task description' } },
               'deprecated' => false,
               'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] },
             'patch' =>
@@ -334,8 +334,8 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
               'summary' => 'patch summary',
               'description' => 'patch description',
               'responses' =>
-              { '204' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
+              { '204' => { 'description' => 'task description' },
+                '404' => { 'description' => 'task description' } },
               'deprecated' => false,
               'requestBody' => { '$ref' => '#/components/requestBodies/Task' },
               'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] },
@@ -344,8 +344,8 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
               'summary' => 'put summary',
               'description' => 'put description',
               'responses' =>
-              { '204' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
+              { '204' => { 'description' => 'task description' },
+                '404' => { 'description' => 'task description' } },
               'deprecated' => false,
               'requestBody' => { '$ref' => '#/components/requestBodies/Task' },
               'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] },
@@ -355,7 +355,7 @@ RSpec.describe R2OAS::Schema::V3::PathsObject do
               'description' => 'delete description',
               'responses' =>
               { '200' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } },
-                '404' => { 'description' => 'task description', 'content' => { 'application/json' => { 'schema' => { '$ref' => '#/components/schemas/Task' } } } } },
+                '404' => { 'description' => 'task description' } },
               'deprecated' => false,
               'parameters' => [{ 'name' => 'id', 'in' => 'path', 'description' => 'id', 'required' => true, 'schema' => { 'type' => 'integer' } }] } }
       end

--- a/spec/r2-oas/tasks/tool_spec.rb
+++ b/spec/r2-oas/tasks/tool_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'tool_rake' do
     end
 
     it do
-      expect(FileTest.exists?("#{deploy_dir_path}")).to eq true
+      expect(FileTest.exists?(deploy_dir_path.to_s)).to eq true
       expect(FileTest.exists?("#{deploy_dir_path}/#{doc_save_file_name}")).to eq true
     end
   end

--- a/spec/support/helpers/config_helper.rb
+++ b/spec/support/helpers/config_helper.rb
@@ -63,6 +63,7 @@ module ConfigHelper
       }
 
       config.http_methods_when_generate_request_body = %w[post patch put]
+      config.ignored_http_statuses_when_generate_component_schema = %w[204 404]
 
       config.tool.paths_stats.configure do |paths_stats|
         paths_stats.month_to_turn_to_warning_color = 3


### PR DESCRIPTION
### Summary

Fix #98 #102

Do not generate component schema when http_status eq  204 and 404

![image](https://user-images.githubusercontent.com/11146767/79989885-55ce8400-84eb-11ea-829f-29ca1502c851.png)

## RSpec

```
Finished in 11.57 seconds (files took 1.81 seconds to load)
198 examples, 0 failures

[Coveralls] Outside the CI environment, not sending data.
```

## Rubocop

```
$ be rubocop
Inspecting 153 files
.........................................................................................................................................................

153 files inspected, no offenses detected
```