### PR TITLE
Fix clash when edit (#108)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -222,3 +222,7 @@ Style/ClassAndModuleChildren:
 Lint/RequireParentheses:
   Exclude:
     - "spec/r2-oas/schema/v3/object/components/schema_object_spec.rb"
+
+Style/IfUnlessModifier:
+  Exclude:
+    - "lib/r2-oas/schema/editor.rb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       paint
       rails (>= 4.2.5)
       terminal-table (~> 1.6.0)
-      watir (~> 6.0)
+      watir (~> 6.16.5)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/r2-oas/schema/editor.rb
+++ b/lib/r2-oas/schema/editor.rb
@@ -77,10 +77,11 @@ module R2OAS
         EM.add_periodic_timer(interval_to_save_edited_tmp_schema) do
           m = Mutex.new
           return nil unless @browser.exists?
+
           m.synchronize do
             begin
               save_after_fetch_local_strage
-            rescue Selenium::WebDriver::Error::UnexpectedAlertOpenError => e
+            rescue Selenium::WebDriver::Error::UnexpectedAlertOpenError
               alert = @browser.driver.switch_to.alert
               if alert.text.eql?(ALERT_TEXT)
                 alert.accept && save_after_fetch_local_strage

--- a/lib/r2-oas/schema/editor.rb
+++ b/lib/r2-oas/schema/editor.rb
@@ -73,7 +73,9 @@ module R2OAS
 
       def ensure_save_tmp_schema_file
         EM.add_periodic_timer(interval_to_save_edited_tmp_schema) do
-          if @browser.exists?
+          m = Mutex.new
+          return nil unless @browser.exists?
+          m.synchronize do
             @after_schema_data = @browser.driver.local_storage[storage_key] || @after_schema_data
             save_edited_schema
             puts "\nwait for signal trap ..."

--- a/lib/r2-oas/schema/editor.rb
+++ b/lib/r2-oas/schema/editor.rb
@@ -27,6 +27,7 @@ module R2OAS
         super(options)
         @editor = swagger.editor
         @before_schema_data = before_schema_data
+        @schema_doc_from_local = YAML.load_file(doc_save_file_path).to_yaml
       end
 
       def start
@@ -96,8 +97,7 @@ module R2OAS
         @browser ||= Watir::Browser.new(:chrome, capabilities)
         @browser.goto(url)
         if wait_for_loaded
-          schema_doc_from_local = YAML.load_file(doc_save_file_path)
-          @browser.driver.local_storage[storage_key] = schema_doc_from_local.to_yaml
+          @browser.driver.local_storage[storage_key] = @schema_doc_from_local
           @browser.refresh
         end
       end

--- a/r2-oas.gemspec
+++ b/r2-oas.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'paint'
   spec.add_runtime_dependency 'rails', '>= 4.2.5'
   spec.add_runtime_dependency 'terminal-table', '~> 1.6.0'
-  spec.add_runtime_dependency 'watir', '~> 6.0'
+  spec.add_runtime_dependency 'watir', '~> 6.16.5'
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
### Summary

Fix #108 

An error occurred when the save ran when the alert was displayed like this

![image](https://user-images.githubusercontent.com/11146767/80357452-f939e300-88b5-11ea-9188-a1b587fecbc2.png)

```
2020-04-27 17:10:45 WARN Selenium [DEPRECATION] Selenium::WebDriver::Error::UnhandledAlertError is deprecated. Use Selenium::WebDriver::Error::UnexpectedAlertOpenError (ensure the driver supports W3C WebDriver specification) instead.
Selenium::WebDriver::Error::UnexpectedAlertOpenError: unexpected alert open: {Alert text : Would you like to convert your JSON into YAML?}
  (Session info: chrome=81.0.4044.122)
  (Driver info: chromedriver=80.0.3987.16 (320f6526c1632ad4f205ebce69b99a062ed78647-refs/branch-heads/3987@{#185}),platform=Mac OS X 10.14.5 x86_64)
from /Users/fukudayu/Zenlogic/phoenix-development-kit/projects/leonacore/work/vendor/bundle/ruby/2.3.0/gems/selenium-webdriver-3.142.7/lib/selenium/webdriver/remote/response.rb:72:in `assert_ok'
```

This is an error to the effect that I want to manage the open alert before accessing the local storage.

## Work

- Exclusive access to local storage to save data (Using Mutex)
- The fix is ​​to accept the `Would you like to convert your JSON into YAML?` alert if it's displayed and then save it.
- As for Selenium error, I gave a version of watir to mute the application warning

I still get some warnings but I can't erase them...

<details>

```
$ PATHS_FILE=./oas_docs/src/paths/api/v2/post.yml bundle exec rake routes:oas:editor
I, [2020-04-27T18:56:25.418364 #9596]  INFO -- : [R2-OAS] start
I, [2020-04-27T18:56:25.507094 #9596]  INFO -- : [Generate OAS schema files] start
I, [2020-04-27T18:56:25.507133 #9596]  INFO -- : [Generate OAS schema files] end
I, [2020-04-27T18:56:25.507144 #9596]  INFO -- : [Generate OAS docs from schema files] start
I, [2020-04-27T18:56:25.508034 #9596]  INFO -- :  Use schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/openapi.yml
I, [2020-04-27T18:56:25.508425 #9596]  INFO -- :  Use schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/external_docs.yml
I, [2020-04-27T18:56:25.509063 #9596]  INFO -- :  Use schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/tags.yml
I, [2020-04-27T18:56:25.509547 #9596]  INFO -- :  Use schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/info.yml
I, [2020-04-27T18:56:25.509967 #9596]  INFO -- :  Use schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/servers.yml
I, [2020-04-27T18:56:25.511509 #9596]  INFO -- :  Use schema file: 	./oas_docs/src/paths/api/v2/post.yml
I, [2020-04-27T18:56:25.512077 #9596]  INFO -- :  Use schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/components/schemas/api/v2/post.yml
I, [2020-04-27T18:56:25.512312 #9596]  INFO -- :  Use schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/components/requestBodies/api/v2/post.yml
I, [2020-04-27T18:56:25.532341 #9596]  INFO -- : [Generate OAS docs from schema files] end

wait for signal trap ...
2020-04-27 18:56:58 WARN Selenium [DEPRECATION] Selenium::WebDriver::Error::UnhandledAlertError is deprecated. Use Selenium::WebDriver::Error::UnexpectedAlertOpenError (ensure the driver supports W3C WebDriver specification) instead.

wait for signal trap ...

wait for signal trap ...

wait for signal trap ...

wait for signal trap ...
^CI, [2020-04-27T18:57:59.478160 #9596]  INFO -- : [Analyze OAS file] start
I, [2020-04-27T18:57:59.485069 #9596]  INFO -- : [Analyze OAS file (tags)] start
I, [2020-04-27T18:57:59.486442 #9596]  INFO -- :   Write schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/tags.yml
I, [2020-04-27T18:57:59.486465 #9596]  INFO -- : [Analyze OAS file (tags)] end
I, [2020-04-27T18:57:59.486477 #9596]  INFO -- : [Analyze OAS file (paths)] start
I, [2020-04-27T18:57:59.492152 #9596]  INFO -- :   Write schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/paths/api/v2/post.yml
I, [2020-04-27T18:57:59.492185 #9596]  INFO -- : [Analyze OAS file (paths)] end
I, [2020-04-27T18:57:59.492235 #9596]  INFO -- : [Analyze OAS file (components)] start
I, [2020-04-27T18:57:59.492250 #9596]  INFO -- : [Analyze OAS file (components/schemas)] start
I, [2020-04-27T18:57:59.495393 #9596]  INFO -- :   Write schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/components/schemas/api/v2/post.yml
I, [2020-04-27T18:57:59.495423 #9596]  INFO -- : [Analyze OAS file (components/schemas)] end
I, [2020-04-27T18:57:59.495434 #9596]  INFO -- : [Analyze OAS file (components/requestBodies)] start
I, [2020-04-27T18:57:59.497396 #9596]  INFO -- :   Write schema file: 	/Users/yukihirop/RubyProjects/r2-oas/example-523/oas_docs/src/components/requestBodies/api/v2/post.yml
I, [2020-04-27T18:57:59.497421 #9596]  INFO -- : [Analyze OAS file (components/requestBodies)] end
I, [2020-04-27T18:57:59.497434 #9596]  INFO -- : [Analyze OAS file (components/securitySchemes)] start
I, [2020-04-27T18:57:59.498175 #9596]  INFO -- : [Analyze OAS file (components/securitySchemes)] end
I, [2020-04-27T18:57:59.502677 #9596]  INFO -- : [Analyze OAS file (components/parameters)] start
I, [2020-04-27T18:57:59.503489 #9596]  INFO -- : [Analyze OAS file (components/parameters)] end
I, [2020-04-27T18:57:59.503511 #9596]  INFO -- : [Analyze OAS file (components/responses)] start
I, [2020-04-27T18:57:59.504486 #9596]  INFO -- : [Analyze OAS file (components/responses)] end
I, [2020-04-27T18:57:59.504509 #9596]  INFO -- : [Analyze OAS file (components/examples)] start
I, [2020-04-27T18:57:59.505320 #9596]  INFO -- : [Analyze OAS file (components/examples)] end
I, [2020-04-27T18:57:59.505355 #9596]  INFO -- : [Analyze OAS file (components/headers)] start
I, [2020-04-27T18:57:59.506201 #9596]  INFO -- : [Analyze OAS file (components/headers)] end
I, [2020-04-27T18:57:59.506233 #9596]  INFO -- : [Analyze OAS file (components/links)] start
I, [2020-04-27T18:57:59.506917 #9596]  INFO -- : [Analyze OAS file (components/links)] end
I, [2020-04-27T18:57:59.506940 #9596]  INFO -- : [Analyze OAS file (components/callbacks)] start
I, [2020-04-27T18:57:59.507475 #9596]  INFO -- : [Analyze OAS file (components/callbacks)] end
I, [2020-04-27T18:57:59.507489 #9596]  INFO -- : [Analyze OAS file (components)] end
I, [2020-04-27T18:57:59.507499 #9596]  INFO -- : [Analyze OAS file] end
I, [2020-04-27T18:57:59.698026 #9596]  INFO -- : container id: 8ea16e8c0c8b8ae634470caacfd0bb8737fdd52ceac58e7206b45f1f1722e55a removed
I, [2020-04-27T18:57:59.698745 #9596]  INFO -- : [R2-OAS] end
```

</details>