### PR TITLE
Update travis config to avoid error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.3
+  - 2.5.1
+  - 2.5.7
+  - 2.6.5
 
 before_install: gem install bundler -v 1.17.3
 


### PR DESCRIPTION
## Summary

Bacause...

```
$ bundle install
Fetching gem metadata from https://rubygems.org/.........
zeitwerk-2.3.0 requires ruby version >= 2.4.4, which is incompatible with the
current version, ruby 2.3.3p222
The command "bundle install" failed and exited with 5 during .
Your build has been stopped.
```

[ref]
https://travis-ci.org/github/yukihirop/r2-oas/jobs/680047491