### PR TITLE
Remove runtime dependencies rails (all)

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -10,7 +10,7 @@
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
-Metrics/LineLength:
+Layout/LineLength:
   Max: 2088
 
 Metrics/AbcSize:
@@ -280,3 +280,12 @@ Style/SlicingWithRange:
 Lint/NonDeterministicRequireOrder:
   Exclude:
     - "spec/spec_helper.rb"
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
+  Enabled: false

--- a/GEMSPEC.md
+++ b/GEMSPEC.md
@@ -1,7 +1,7 @@
 Configureless and no DSL. 👍 But you can also configure.  
 Manage with yaml file instead of Ruby code.  
 Loosely coupled to your Rails project. 👍  
-So If it doesn't, you can always stop easily. 😢  
+So if you want to use another tool, you can port it right away. 😢  
 Generate api docment(OpenAPI) side only from `Rails` routing.  
   
 Provide rake tasks to management API Docment (OpenAPI) 🎉  

--- a/GEMSPEC.md
+++ b/GEMSPEC.md
@@ -1,4 +1,5 @@
 Configureless and no DSL. 👍 But you can also configure.  
+Manage with yaml file instead of Ruby code.  
 Loosely coupled to your Rails project. 👍  
 So If it doesn't, you can always stop easily. 😢  
 Generate api docment(OpenAPI) side only from `Rails` routing.  

--- a/lib/r2-oas.rb
+++ b/lib/r2-oas.rb
@@ -6,8 +6,6 @@ require 'r2-oas/errors'
 require 'r2-oas/schema/v3/object/public'
 
 module R2OAS
-  extend ActiveSupport::Autoload
-
   if !defined?(::Rails)
     raise NoImplementError, 'Can not load Rails'
   # support Rails version
@@ -22,8 +20,6 @@ module R2OAS
     autoload :Sortable, 'r2-oas/shared/all'
 
     module Schema
-      extend ActiveSupport::Autoload
-
       autoload :Base, 'r2-oas/schema/base'
       autoload :Generator, 'r2-oas/schema/generator'
       autoload :Builder, 'r2-oas/schema/builder'

--- a/lib/r2-oas.rb
+++ b/lib/r2-oas.rb
@@ -12,6 +12,7 @@ module R2OAS
   elsif ::Rails::VERSION::STRING >= '4.2.5.1'
     extend Configuration
     require 'r2-oas/task'
+    require 'r2-oas/lib/core_ext/hash/deep_merge'
 
     autoload :Base, 'r2-oas/base'
     autoload :NoImplementError, 'r2-oas/errors'

--- a/lib/r2-oas.rb
+++ b/lib/r2-oas.rb
@@ -13,6 +13,7 @@ module R2OAS
     extend Configuration
     require 'r2-oas/task'
     require 'r2-oas/lib/core_ext/hash/deep_merge'
+    require 'r2-oas/lib/core_ext/object/blank'
 
     autoload :Base, 'r2-oas/base'
     autoload :NoImplementError, 'r2-oas/errors'

--- a/lib/r2-oas/lib/core_ext/hash/deep_merge.rb
+++ b/lib/r2-oas/lib/core_ext/hash/deep_merge.rb
@@ -1,0 +1,40 @@
+# Copy From https://github.com/rails/rails/blob/v4.2.5/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
+
+class Hash
+  # Returns a new hash with +self+ and +other_hash+ merged recursively.
+  #
+  #   h1 = { a: true, b: { c: [1, 2, 3] } }
+  #   h2 = { a: false, b: { x: [3, 4, 5] } }
+  #
+  #   h1.deep_merge(h2) #=> { a: false, b: { c: [1, 2, 3], x: [3, 4, 5] } }
+  #
+  # Like with Hash#merge in the standard library, a block can be provided
+  # to merge values:
+  #
+  #   h1 = { a: 100, b: 200, c: { c1: 100 } }
+  #   h2 = { b: 250, c: { c1: 200 } }
+  #   h1.deep_merge(h2) { |key, this_val, other_val| this_val + other_val }
+  #   # => { a: 100, b: 450, c: { c1: 300 } }
+  def deep_merge(other_hash, &block)
+    dup.deep_merge!(other_hash, &block)
+  end
+
+  # Same as +deep_merge+, but modifies +self+.
+  def deep_merge!(other_hash, &block)
+    other_hash.each_pair do |current_key, other_value|
+      this_value = self[current_key]
+
+      self[current_key] = if this_value.is_a?(Hash) && other_value.is_a?(Hash)
+        this_value.deep_merge(other_value, &block)
+      else
+        if block_given? && key?(current_key)
+          block.call(current_key, this_value, other_value)
+        else
+          other_value
+        end
+      end
+    end
+
+    self
+  end
+end

--- a/lib/r2-oas/lib/core_ext/hash/deep_merge.rb
+++ b/lib/r2-oas/lib/core_ext/hash/deep_merge.rb
@@ -1,5 +1,8 @@
+# frozen_string_literal: true
+
 # Copy From https://github.com/rails/rails/blob/v4.2.5/activesupport/lib/active_support/core_ext/hash/deep_merge.rb
 
+# rubocop:disable all
 class Hash
   # Returns a new hash with +self+ and +other_hash+ merged recursively.
   #
@@ -38,3 +41,4 @@ class Hash
     self
   end
 end
+# rubocop:enable all

--- a/lib/r2-oas/lib/core_ext/object/blank.rb
+++ b/lib/r2-oas/lib/core_ext/object/blank.rb
@@ -1,6 +1,8 @@
-# encoding: utf-8
+# frozen_string_literal: true
 
 # Copy From https://github.com/rails/rails/blob/v4.2.5/activesupport/lib/active_support/core_ext/object/blank.rb
+
+# rubocop:disable all
 class Object
   # An object is blank if it's false, empty, or a whitespace string.
   # For example, +false+, '', '   ', +nil+, [], and {} are all blank.
@@ -130,3 +132,4 @@ class Numeric #:nodoc:
     false
   end
 end
+# rubocop:enable all

--- a/lib/r2-oas/lib/core_ext/object/blank.rb
+++ b/lib/r2-oas/lib/core_ext/object/blank.rb
@@ -1,0 +1,132 @@
+# encoding: utf-8
+
+# Copy From https://github.com/rails/rails/blob/v4.2.5/activesupport/lib/active_support/core_ext/object/blank.rb
+class Object
+  # An object is blank if it's false, empty, or a whitespace string.
+  # For example, +false+, '', '   ', +nil+, [], and {} are all blank.
+  #
+  # This simplifies
+  #
+  #   !address || address.empty?
+  #
+  # to
+  #
+  #   address.blank?
+  #
+  # @return [true, false]
+  def blank?
+    respond_to?(:empty?) ? !!empty? : !self
+  end
+
+  # An object is present if it's not blank.
+  #
+  # @return [true, false]
+  def present?
+    !blank?
+  end
+
+  # Returns the receiver if it's present otherwise returns +nil+.
+  # <tt>object.presence</tt> is equivalent to
+  #
+  #    object.present? ? object : nil
+  #
+  # For example, something like
+  #
+  #   state   = params[:state]   if params[:state].present?
+  #   country = params[:country] if params[:country].present?
+  #   region  = state || country || 'US'
+  #
+  # becomes
+  #
+  #   region = params[:state].presence || params[:country].presence || 'US'
+  #
+  # @return [Object]
+  def presence
+    self if present?
+  end
+end
+
+class NilClass
+  # +nil+ is blank:
+  #
+  #   nil.blank? # => true
+  #
+  # @return [true]
+  def blank?
+    true
+  end
+end
+
+class FalseClass
+  # +false+ is blank:
+  #
+  #   false.blank? # => true
+  #
+  # @return [true]
+  def blank?
+    true
+  end
+end
+
+class TrueClass
+  # +true+ is not blank:
+  #
+  #   true.blank? # => false
+  #
+  # @return [false]
+  def blank?
+    false
+  end
+end
+
+class Array
+  # An array is blank if it's empty:
+  #
+  #   [].blank?      # => true
+  #   [1,2,3].blank? # => false
+  #
+  # @return [true, false]
+  alias_method :blank?, :empty?
+end
+
+class Hash
+  # A hash is blank if it's empty:
+  #
+  #   {}.blank?                # => true
+  #   { key: 'value' }.blank?  # => false
+  #
+  # @return [true, false]
+  alias_method :blank?, :empty?
+end
+
+class String
+  BLANK_RE = /\A[[:space:]]*\z/
+
+  # A string is blank if it's empty or contains whitespaces only:
+  #
+  #   ''.blank?       # => true
+  #   '   '.blank?    # => true
+  #   "\t\n\r".blank? # => true
+  #   ' blah '.blank? # => false
+  #
+  # Unicode whitespace is supported:
+  #
+  #   "\u00a0".blank? # => true
+  #
+  # @return [true, false]
+  def blank?
+    BLANK_RE === self
+  end
+end
+
+class Numeric #:nodoc:
+  # No number is blank:
+  #
+  #   1.blank? # => false
+  #   0.blank? # => false
+  #
+  # @return [false]
+  def blank?
+    false
+  end
+end

--- a/lib/r2-oas/lib/core_ext/object/blank.rb
+++ b/lib/r2-oas/lib/core_ext/object/blank.rb
@@ -100,7 +100,7 @@ class Hash
 end
 
 class String
-  BLANK_RE = /\A[[:space:]]*\z/
+  BLANK_REGEXP = /\A[[:space:]]*\z/
 
   # A string is blank if it's empty or contains whitespaces only:
   #
@@ -115,7 +115,7 @@ class String
   #
   # @return [true, false]
   def blank?
-    BLANK_RE === self
+    BLANK_REGEXP === self
   end
 end
 

--- a/r2-oas.gemspec
+++ b/r2-oas.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'eventmachine', '>= 1.2.0'
   spec.add_runtime_dependency 'key_flatten', '>= 1.0.0'
   spec.add_runtime_dependency 'paint'
-  spec.add_runtime_dependency 'rails', '>= 4.2.5'
+  spec.add_runtime_dependency 'railties', '>= 4.2.5'
   spec.add_runtime_dependency 'terminal-table', '>= 1.6.0'
   spec.add_runtime_dependency 'watir', '>= 6.16.5'
   spec.add_development_dependency 'bundler', '>= 1.17'
@@ -47,4 +47,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'appraisal'
+  spec.add_development_dependency 'activerecord', '>= 4.2.5'
 end

--- a/spec/r2-oas/store_spec.rb
+++ b/spec/r2-oas/store_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'r2-oas/store'
 
-# rubocop:disable Metrics/BlockLength, Metrics/LineLength
+# rubocop:disable Metrics/BlockLength, Layout/LineLength
 RSpec.describe R2OAS::Store do
   let(:servers) { "---\nservers:\n- url: http://localhost:3000\n  description: localhost\n" }
   let(:tags) { "---\ntags:\n- name: api/v2/post\n  description: api/v2/post description\n  externalDocs:\n    description: description\n    url: url\n- name: api/v1/task\n  description: api/v1/task description\n  externalDocs:\n    description: description\n    url: url\n- name: user\n  description: user description\n  externalDocs:\n    description: description\n    url: url\n- name: active_storage/blob\n  description: active_storage/blob description\n  externalDocs:\n    description: description\n    url: url\n- name: active_storage/representation\n  description: active_storage/representation description\n  externalDocs:\n    description: description\n    url: url\n- name: active_storage/disk\n  description: active_storage/disk description\n  externalDocs:\n    description: description\n    url: url\n- name: active_storage/direct_upload\n  description: active_storage/direct_upload description\n  externalDocs:\n    description: description\n    url: url\n" }
@@ -154,4 +154,4 @@ RSpec.describe R2OAS::Store do
     end
   end
 end
-# rubocop:enable Metrics/BlockLength, Metrics/LineLength
+# rubocop:enable Metrics/BlockLength, Layout/LineLength


### PR DESCRIPTION
## Summary

Resolve #130 

There was a waste of runtime dependencies, so I reviewed it.

#### before 

- actioncable
- actionmailbox
- actionmailer
- actionpack
- actionview
- actionjob
- actionmodel
- activeview
- activejob
- activerecord
- activestorage
- activesupport
- railtie

#### after

- railtie
  - actionpack
    - activesupport
    - actionview
  - activesupport

↓

- railtie
- actionpack
- activesupport
- actionview (It's not really necessary, but it is inevitable because actionpack depends on it)

### all_support_ruby rspec

```
===== Rspec for All Support Ruby Result =====
ruby-2.3.3: 0
ruby-2.4.2: 0
ruby-2.5.8: 0
ruby-2.6.6: 0
ruby-2.7.1: 0
=============================================
```