### PR TITLE
Implement R2OAS::Deprecation && Deprecated use of R2OAS.use_object_classes=

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -168,8 +168,7 @@ Naming/PredicateName:
     - "lib/r2-oas/plugin/hookable.rb"
 
 Style/DoubleNegation:
-  Exclude:
-    - "lib/r2-oas/hooks/hook.rb"
+  Enabled: false
 
 Style/MultilineBlockChain:
   Exclude:
@@ -378,3 +377,7 @@ Style/HashLikeCase:
 
 Style/RedundantFileExtensionInRequire:
   Enabled: true
+
+Style/StderrPuts:
+  Exclude:
+    - "lib/r2-oas/support/deprecation/behavior.rb"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -30,6 +30,7 @@ Metrics/AbcSize:
     - "lib/r2-oas/plugin/executor.rb"
     - "lib/r2-oas/schema/v3/builder/doc_builder.rb"
     - "lib/r2-oas/configuration.rb"
+    - "lib/r2-oas/app_configuration.rb"
 
 Style/Documentation:
   Enabled: false

--- a/docs/setting/configure.md
+++ b/docs/setting/configure.md
@@ -79,10 +79,15 @@ R2OAS.configure do |config|
     paths_stats.heading_color                  = :yellow
     paths_stats.highlight_color                = :magenta
   end
+  
   config.plugins = []
+  
   config.local_plugins_dir_name = 'plugins'
   config.local_tasks_dir_name = 'tasks'
+  
   config.output_path = './oas_docs/dist/oas_doc.yml'
+  
+  config.deprecation.silenced = false
 end
 ```
 
@@ -145,6 +150,12 @@ we explain the options that can be set.
 |tool|paths_stats|highlight_color|Highlight Color|`:magenta`|
 
 Please refer to [here](https://github.com/janlelis/paint) for the color.
+
+#### deprecation
+
+|option|children option|description|default|
+|------|---------------|-----------|-------|
+|deprecation|silenced|silence deprecated warnings|`false`|
 
 ## Environment variables
 

--- a/lib/r2-oas.rb
+++ b/lib/r2-oas.rb
@@ -19,6 +19,7 @@ module R2OAS
     autoload :NoFileExistsError, 'r2-oas/errors'
     autoload :NoSupportError, 'r2-oas/errors'
     autoload :Sortable, 'r2-oas/shared/all'
+    autoload :Deprecation, 'r2-oas/support/deprecation'
 
     module Schema
       autoload :Base, 'r2-oas/schema/base'

--- a/lib/r2-oas/app_configuration.rb
+++ b/lib/r2-oas/app_configuration.rb
@@ -3,6 +3,7 @@
 require_relative 'app_configuration/server'
 require_relative 'app_configuration/swagger'
 require_relative 'app_configuration/tool'
+require_relative 'app_configuration/deprecation'
 
 module R2OAS
   module AppConfiguration
@@ -50,6 +51,7 @@ module R2OAS
     DEFAULT_LOCAL_PLUGINS_DIR_NAME = 'plugins'
     DEFAULT_LOCAL_TASKS_DIR_NAME = 'tasks'
     DEFAULT_OUTPUT_PATH = './oas_docs/dist/oas_doc.yml'
+    DEFAULT_DEPRECATION = Deprecation.new
 
     PUBLIC_VALID_OPTIONS_KEYS = %i[
       version
@@ -72,6 +74,7 @@ module R2OAS
       local_plugins_dir_name
       local_tasks_dir_name
       output_path
+      deprecation
     ].freeze
 
     UNPUBLIC_VALID_OPTIONS_KEYS = %i[
@@ -112,6 +115,7 @@ module R2OAS
       target.local_plugins_dir_name                               = DEFAULT_LOCAL_PLUGINS_DIR_NAME
       target.local_tasks_dir_name                                 = DEFAULT_LOCAL_TASKS_DIR_NAME
       target.output_path                                          = DEFAULT_OUTPUT_PATH
+      target.deprecation                                          = DEFAULT_DEPRECATION
     end
   end
 end

--- a/lib/r2-oas/app_configuration/deprecation.rb
+++ b/lib/r2-oas/app_configuration/deprecation.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'r2-oas/support/deprecation'
+
+module R2OAS
+  module AppConfiguration
+    class Deprecation
+      DEFAULT_SILENCED = ::R2OAS::Deprecation.silenced
+
+      attr_reader :silenced
+
+      def silenced=(value)
+        @silenced = !!value
+        ::R2OAS::Deprecation.silenced = !!value
+      end
+
+      def initialize
+        set_default
+      end
+
+      private
+
+      def set_default
+        self.silenced = DEFAULT_SILENCED
+      end
+    end
+  end
+end

--- a/lib/r2-oas/configuration.rb
+++ b/lib/r2-oas/configuration.rb
@@ -6,6 +6,7 @@ require_relative 'app_configuration'
 require_relative 'pluggable_configuration'
 require_relative 'configuration/paths_config'
 require_relative 'logger/stdout_logger'
+require_relative 'support/deprecation'
 
 module R2OAS
   module Configuration
@@ -22,6 +23,15 @@ module R2OAS
     VALID_OPTIONS_KEYS = PUBLIC_VALID_OPTIONS_KEYS + UNPUBLIC_VALID_OPTIONS_KEYS
 
     attr_accessor *PUBLIC_VALID_OPTIONS_KEYS
+
+    # MEMO: override because deprecated
+    def use_object_classes=(data)
+      ::R2OAS::Deprecation.will_remove(<<-MSG.squish)
+        Using a R2OAS.use_object_classes= in configuration is deprecated and
+        will be removed in r2-oas (v0.4.2).
+      MSG
+      @use_object_classes = data
+    end
 
     def self.extended(base)
       base.send :set_default_for_configuration, base

--- a/lib/r2-oas/pluggable_configuration.rb
+++ b/lib/r2-oas/pluggable_configuration.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'r2-oas/schema/v3/object/from_routes/public'
+require_relative 'support/deprecation'
 
 module R2OAS
   module PluggableConfiguration
@@ -20,14 +21,16 @@ module R2OAS
       use_object_classes
     ].freeze
 
-    attr_accessor *VALID_OPTIONS_KEYS
+    attr_reader *VALID_OPTIONS_KEYS
 
     private
 
     module_function
 
     def set_default(target)
-      target.use_object_classes = DEFAULT_USE_OBJECT_CLASSES
+      Deprecation.silence do
+        target.use_object_classes = DEFAULT_USE_OBJECT_CLASSES
+      end
     end
   end
 end

--- a/lib/r2-oas/support/deprecation.rb
+++ b/lib/r2-oas/support/deprecation.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require_relative 'deprecation/instance_delegator'
+require_relative 'deprecation/reporting'
+require_relative 'deprecation/behavior'
+
+module R2OAS
+  class Deprecation
+    include Singleton
+    # Be sure to follow the Singleton module
+    include InstanceDelegator
+    include Behavior
+    include Reporting
+
+    # The version number in which the deprecated behavior will be removed, by default.
+    attr_accessor :deprecation_horizon
+
+    def initialize(deprecation_horizon = '0.4.2', gem_name = 'r2-oas')
+      self.gem_name = gem_name
+      self.deprecation_horizon = deprecation_horizon
+      self.silenced = false
+    end
+  end
+end

--- a/lib/r2-oas/support/deprecation/behavior.rb
+++ b/lib/r2-oas/support/deprecation/behavior.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+# MEMO:
+# copy from https://github.com/rails/rails/blob/master/activesupport/lib/active_support/deprecation/behaviors.rb
+module R2OAS
+  class Deprecation
+    class DeprecationError < StandardError; end
+
+    DEFAULT_BEHAVIORS = {
+      stderr: lambda { |message, _callstack, _deprecation_horizon, _gem_name|
+        $stderr.puts(message)
+      }
+    }.freeze
+
+    module Behavior
+      def behavior
+        @behavior ||= [DEFAULT_BEHAVIORS[:stderr]]
+      end
+    end
+  end
+end

--- a/lib/r2-oas/support/deprecation/instance_delegator.rb
+++ b/lib/r2-oas/support/deprecation/instance_delegator.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'forwardable'
+
+# copy from https://github.com/rails/rails/blob/master/activesupport/lib/active_support/deprecation/instance_delegator.rb
+module R2OAS
+  class Deprecation
+    module InstanceDelegator
+      # MEMO:
+      # base must be singleton class
+      def self.included(base)
+        base.extend(ClassMethods)
+        base.singleton_class.extend(Forwardable)
+        base.singleton_class.prepend(OverrideDelegators)
+        base.public_class_method :new
+      end
+
+      module ClassMethods
+        # override Module#include
+        def include(included_module)
+          included_module.instance_methods.each { |m| method_added(m) }
+          super
+        end
+
+        def method_added(method_name)
+          singleton_class.def_delegators(:instance, method_name)
+        end
+      end
+
+      module OverrideDelegators
+        def warn(message = nil, callstack = nil)
+          # MEMO:
+          # Why update callstack
+          # https://github.com/rails/rails/pull/26686
+          callstack ||= caller_locations(2)
+          super
+        end
+        alias will_remove warn
+      end
+    end
+  end
+end

--- a/lib/r2-oas/support/deprecation/reporting.rb
+++ b/lib/r2-oas/support/deprecation/reporting.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+# MEMO:
+# copy from https://github.com/rails/rails/blob/master/activesupport/lib/active_support/deprecation/reporting.rb
+module R2OAS
+  class Deprecation
+    module Reporting
+      attr_accessor :silenced, :gem_name
+
+      FILE_LINE_METHOD_REGEXP = /^(?<file>.+?):(?<line>\d+)(?::in `(?<method>.*?)')?/.freeze
+      R2OAS_GEM_ROOT = File.expand_path('../../../../', __dir__) + '/lib'
+
+      def warn(message = nil, callstack = nil)
+        return if silenced
+
+        callstack ||= caller_locations(2)
+        deprecation_message(callstack, message).tap do |msg|
+          behavior.each { |b| b.call(msg, callstack, deprecation_horizon, gem_name) }
+        end
+      end
+      alias will_remove warn
+
+      def silence
+        old_silenced = silenced
+        self.silenced = true
+        yield if block_given?
+        self.silenced = old_silenced
+      end
+
+      private
+
+      def deprecation_message(callstack, message = nil)
+        message ||= 'You are using deprecated behavior which will be removed from the next major or minor release.'
+        "DEPRECATION WARNING: #{message} #{deprecation_caller_message(callstack)}"
+      end
+
+      def deprecation_caller_message(callstack)
+        file, line, method = extract_callstack(callstack)
+        if file
+          if line && method
+            "(called from #{method} at #{file}:#{line})"
+          else
+            "(called from #{file}:#{line})"
+          end
+        end
+      end
+
+      def extract_callstack(callstack)
+        return _extract_callback(callstack) if callstack.first.is_a? String
+
+        offending_line = callstack.find do |frame|
+          frame.absolute_path && !ignored_callstack(frame.absolute_path)
+        end || callstack.first
+
+        [offending_line.path, offending_line.lineno, offending_line.label]
+      end
+
+      # e.g.)
+      # callback = /path/to/file.rb:274:in `require'
+      #
+      # file = /path/to/file.rb
+      # line = 274
+      # method = require
+      def _extract_callstack(_callback)
+        warn 'Please pass `caller_options` to the deprecation API' if $VERBOSE
+        offending_line = callstack.find { |line| !ignored_callstack(line) || callstack.first }
+
+        if offendihng_line
+          md = offending_line.match(FILE_LINE_METHOD_REGEXP)
+
+          if md.present?
+            md.captures
+          else
+            offending_line
+          end
+        end
+      end
+
+      # MEMO:
+      # see https://docs.ruby-lang.org/ja/latest/class/RbConfig.html#C_-C-O-N-F-I-G
+      def ignored_callstack(path)
+        # MEMO:
+        #
+        # e.g.)
+        # R2OAS_GEM_ROOT = "/Users/yukihirop/RubyProjects/r2-oas/lib"
+        # rubylibprefix = "/Users/yukihirop/.rbenv/versions/2.7.1/lib/ruby"
+        path.start_with?(R2OAS_GEM_ROOT) || path.start_with?(RbConfig::CONFIG['rubylibprefix'])
+      end
+    end
+  end
+end

--- a/spec/r2-oas/configuration_spec.rb
+++ b/spec/r2-oas/configuration_spec.rb
@@ -75,6 +75,7 @@ RSpec.describe R2OAS::Configuration do
         expect(subject[:local_plugins_dir_name]).to eq 'plugins'
         expect(subject[:local_tasks_dir_name]).to eq 'tasks'
         expect(subject[:output_path]).to eq './oas_docs/dist/oas_doc.yml'
+        expect(subject[:deprecation].silenced).to eq false
       end
     end
 
@@ -162,6 +163,7 @@ RSpec.describe R2OAS::Configuration do
             config.local_plugins_dir_name = 'plugins'
             config.local_tasks_dir_name = 'rake_tasks'
             config.output_path = './dist/oas_doc.yml'
+            config.deprecation.silenced = true
           end
         end
       end
@@ -224,6 +226,30 @@ RSpec.describe R2OAS::Configuration do
         expect(subject[:local_plugins_dir_name]).to eq 'plugins'
         expect(subject[:local_tasks_dir_name]).to eq 'rake_tasks'
         expect(subject[:output_path]).to eq './dist/oas_doc.yml'
+        expect(subject[:deprecation].silenced).to eq true
+      end
+    end
+
+    context 'deprecation warning' do
+      context 'when deprecation.silenced is false (default)' do
+        it do
+          expect do
+            R2OAS.configure do |config|
+              config.use_object_classes = {}
+            end
+          end.to output(/DEPRECATION WARNING: Using a R2OAS.use_object_classes= in configuration is deprecated and will be removed in r2-oas \(v0.4.2\)./).to_stderr
+        end
+      end
+
+      context 'when deprecation.silenced is true' do
+        it do
+          expect do
+            R2OAS.configure do |config|
+              config.deprecation.silenced = true
+              config.use_object_classes = {}
+            end
+          end.not_to output(/DEPRECATION WARNING: Using a R2OAS.use_object_classes= in configuration is deprecated and will be removed in r2-oas \(v0.4.2\)./).to_stderr
+        end
       end
     end
   end

--- a/spec/r2-oas/support/deprecation_spec.rb
+++ b/spec/r2-oas/support/deprecation_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'r2-oas/support/deprecation'
+
+RSpec.describe R2OAS::Deprecation do
+  describe '#warn (will_remove)' do
+    subject do
+      described_class.warn(<<-MSG.squish)
+        Using a :test_method in configuration is deprecated and
+        will be removed in r2-oas (v0.4.2).
+      MSG
+    end
+
+    it { expect { subject }.to output(/DEPRECATION WARNING: Using a :test_method in configuration is deprecated and will be removed in r2-oas \(v0.4.2\)/).to_stderr }
+  end
+end

--- a/spec/support/helpers/config_helper.rb
+++ b/spec/support/helpers/config_helper.rb
@@ -81,6 +81,7 @@ module ConfigHelper
       config.namespace_type = :underbar
       config.plugins = []
       config.output_path = Rails.root.join('oas_docs/dist/oas_doc.yml').to_s
+      config.deprecation.silenced = false
     end
   end
 end


### PR DESCRIPTION
## Summary

Resolve #148

- Implement `R2OAS::Deprecation.warn(will_remove)`
- Add `R2OAS.deprecation.silenced` option into Configuration
- Deprecated use of `R2OAS.use_object_classes=`
- Update docs about `R2OAS.deprecation.silenced` option

Implemented with considerable reference to ActiveSupport::Deprecation

## Work

```ruby
::R2OAS::Deprecation.will_remove(<<-MSG.squish)
     Using a R2OAS.use_object_classes= in configuration is deprecated and
     will be removed in r2-oas (v0.4.2).
MSG
```

```
DEPRECATION WARNING: Using a R2OAS.use_object_classes= in configuration is deprecated and will be removed in r2-oas (v0.4.2). (called from block in reset_config at /Users/fukudayu/RubyProjects/r2-oas/spec/support/helpers/config_helper.rb:32)
```

## Test

```bash
./devscript/all_support_ruby.sh rspec

===== Rspec for All Support Ruby Result =====
ruby-2.3.3: 0
ruby-2.4.2: 0
ruby-2.5.8: 0
ruby-2.6.6: 0
ruby-2.7.1: 0
=============================================
```

## Rubocop

```bash
$ bundle exec rubocop
Inspecting 209 files
.................................................................................................................................................................................................................

209 files inspected, no offenses detected
```