### PR TITLE
Add SKIP_PLUGIN environment variable

### DIFF
--- a/docs/setting/configure.md
+++ b/docs/setting/configure.md
@@ -167,6 +167,7 @@ We explain the environment variables that can be set.
 |OAS_FILE|Specify swagger file path to analyze|`""`|
 |CACHE_DOCS|Effective only when there is no `.docs` file. Specifying `true` will generate a` .docs` file when the `routes:oas:docs` command is executed.|`false`|
 |OVERRIDE_SRC|Apply the plugin to the src file when `routes:oas:build` is executed.|`false`|
+|SKIP_PLUGIN|Skip apply the plugin when `routes:oas:build` is executed.|`false`|
 
 
 ## .paths

--- a/docs/usage/use_plugins.md
+++ b/docs/usage/use_plugins.md
@@ -201,6 +201,15 @@ $ OVERRIDE_SRC=true bundle exec rake routes:oas:build
 
 !> If the applied plugin is not idempotent, the converted data may be unexpected.
 
+### Skip plugin apply
+
+In case you don't want to apply the plugin when building the documentation,  
+Please set the environment variable `SKIP_PLUGIN` to `true`.
+
+```bash
+$ SKIP_PLUGIN=true bundle exec rake routes:oas:build
+```
+
 ## Important
 
 !> Be sure to write the plugin so that it is idempotent.  

--- a/lib/r2-oas/tasks/main.rake
+++ b/lib/r2-oas/tasks/main.rake
@@ -44,7 +44,8 @@ namespace :routes do
         FileUtils.mkdir_p(output_dir_path) unless FileTest.exists?(output_dir_path)
 
         is_overrirde_src = override_src.eql? 'true'
-        builder_options = { unit_paths_file_path: unit_paths_file_path, use_plugin: true, output: true }
+        use_plugin = skip_plugin.eql? 'false'
+        builder_options = { unit_paths_file_path: unit_paths_file_path, use_plugin: use_plugin, output: true }
         builder = R2OAS::Schema::Builder.new(builder_options)
         builder.build_docs
 
@@ -127,6 +128,10 @@ namespace :routes do
 
     def override_src
       ENV.fetch('OVERRIDE_SRC', 'false')
+    end
+
+    def skip_plugin
+      ENV.fetch('SKIP_PLUGIN', 'false')
     end
   end
 end


### PR DESCRIPTION
## Summary

- Resolve #159 
- Add docs about `SKIP_PLUGIN`

## Work

```
(⎈ |minikube:default)#2020-08-18 17:19|yukihirop@FukudanoMacBook-Pro:~/RubyProjects/r2-oas/example-523 (master+)
$ SKIP_PLUGIN=true be rake routes:oas:build
I, [2020-08-18T17:36:59.904228 #13119]  INFO -- : [R2-OAS] start
I, [2020-08-18T17:37:00.087345 #13119]  INFO -- : [Build OAS schema files] start
I, [2020-08-18T17:37:00.087392 #13119]  INFO -- : [Build OAS docs from schema files] start
I, [2020-08-18T17:37:00.090327 #13119]  INFO -- :  Use schema file: 	oas_docs/src/openapi.yml
I, [2020-08-18T17:37:00.091736 #13119]  INFO -- :  Use schema file: 	oas_docs/src/external_docs.yml
I, [2020-08-18T17:37:00.093707 #13119]  INFO -- :  Use schema file: 	oas_docs/src/tags.yml
I, [2020-08-18T17:37:00.095188 #13119]  INFO -- :  Use schema file: 	oas_docs/src/info.yml
I, [2020-08-18T17:37:00.096816 #13119]  INFO -- :  Use schema file: 	oas_docs/src/servers.yml
I, [2020-08-18T17:37:00.098674 #13119]  INFO -- :  Use schema file: 	oas_docs/src/paths/active_storage/disk.yml
I, [2020-08-18T17:37:00.100664 #13119]  INFO -- :  Use schema file: 	oas_docs/src/paths/active_storage/representation.yml
I, [2020-08-18T17:37:00.105543 #13119]  INFO -- :  Use schema file: 	oas_docs/src/paths/active_storage/blob.yml
I, [2020-08-18T17:37:00.107065 #13119]  INFO -- :  Use schema file: 	oas_docs/src/paths/active_storage/direct_upload.yml
I, [2020-08-18T17:37:00.109962 #13119]  INFO -- :  Use schema file: 	oas_docs/src/paths/user.yml
I, [2020-08-18T17:37:00.112760 #13119]  INFO -- :  Use schema file: 	oas_docs/src/paths/api/v1/task.yml
I, [2020-08-18T17:37:00.115430 #13119]  INFO -- :  Use schema file: 	oas_docs/src/paths/api/v2/post.yml
I, [2020-08-18T17:37:00.116548 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/schemas/activestorage/disk.yml
I, [2020-08-18T17:37:00.117815 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/requestBodies/activestorage/disk.yml
I, [2020-08-18T17:37:00.118950 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/schemas/activestorage/representation.yml
I, [2020-08-18T17:37:00.120405 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/schemas/activestorage/blob.yml
I, [2020-08-18T17:37:00.122005 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/schemas/activestorage/direct_upload.yml
I, [2020-08-18T17:37:00.123481 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/requestBodies/activestorage/direct_upload.yml
I, [2020-08-18T17:37:00.124754 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/schemas/user.yml
I, [2020-08-18T17:37:00.125790 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/requestBodies/user.yml
I, [2020-08-18T17:37:00.126817 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/schemas/api/v1/task.yml
I, [2020-08-18T17:37:00.127738 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/requestBodies/api/v1/task.yml
I, [2020-08-18T17:37:00.128746 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/schemas/api/v2/post.yml
I, [2020-08-18T17:37:00.129769 #13119]  INFO -- :  Use schema file: 	oas_docs/src/components/requestBodies/api/v2/post.yml
I, [2020-08-18T17:37:00.165786 #13119]  INFO -- : [Build OAS docs from schema files] end
I, [2020-08-18T17:37:00.165822 #13119]  INFO -- : [Build OAS schema files] end
I, [2020-08-18T17:37:00.165836 #13119]  INFO -- : [R2-OAS] end
```

