### PR TITLE
use ::Rails::Railtie

### DIFF
--- a/lib/r2-oas.rb
+++ b/lib/r2-oas.rb
@@ -9,6 +9,7 @@ module R2OAS
   # support Rails version
   elsif ::Rails::VERSION::STRING >= '4.2.5.1'
     extend Configuration
+    require 'r2-oas/task'
     require 'r2-oas/plugin/public'
     require 'r2-oas/lib/core_ext/all'
 

--- a/lib/r2-oas/configuration.rb
+++ b/lib/r2-oas/configuration.rb
@@ -71,7 +71,6 @@ module R2OAS
 
     def load_tasks
       load_local_tasks
-      load_builtin_tasks
     end
 
     def init
@@ -104,13 +103,6 @@ module R2OAS
     def load_local_tasks
       tasks_path = File.expand_path("#{root_dir_path}/#{local_tasks_dir_name}")
       Dir.glob("#{tasks_path}/**/*.rake").sort.each do |file|
-        load file if FileTest.exists?(file)
-      end
-    end
-
-    def load_builtin_tasks
-      tasks_path = File.expand_path("#{__dir__}/tasks")
-      ["#{tasks_path}/main.rake"].sort.each do |file|
         load file if FileTest.exists?(file)
       end
     end

--- a/lib/r2-oas/task.rb
+++ b/lib/r2-oas/task.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module R2OAS
+  class Task < ::Rails::Railtie
+    rake_tasks do
+      main_task_path = File.join(File.dirname(__FILE__), './tasks/main.rake')
+      Dir[main_task_path].each { |f| load f }
+    end
+  end
+end


### PR DESCRIPTION
## Summary

You cannot remove the dependency of railtie, and railtie always depends on rails project.
So make full use of railtie's features

## Test

```
===== Rspec for All Support Ruby Result =====
ruby-2.3.3: 0
ruby-2.4.2: 0
ruby-2.5.8: 0
ruby-2.6.6: 0
ruby-2.7.1: 0
=============================================
```