### PR TITLE
Fix Unable to load the EventMachine C extension; To use the pure-ruby reactor, require 'em/pure_ruby'

### DIFF
--- a/gemfiles/ruby_2.4.2.gemfile
+++ b/gemfiles/ruby_2.4.2.gemfile
@@ -5,7 +5,7 @@ source "https://rubygems.org"
 ruby '2.4.2'
 
 group :test do
-  gem "sqlite3"
+  gem 'sqlite3', '~> 1.3.6'
 end
 
 gemspec path: "../"

--- a/lib/r2-oas/schema/editor.rb
+++ b/lib/r2-oas/schema/editor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal:true
 
 require 'docker'
-require 'eventmachine'
+require 'em/pure_ruby'
 require 'watir'
 require 'tempfile'
 require 'fileutils'

--- a/lib/r2-oas/schema/monitor.rb
+++ b/lib/r2-oas/schema/monitor.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal:true
 
-require 'eventmachine'
+require 'em/pure_ruby'
 
 # Scope Rails
 module R2OAS

--- a/lib/r2-oas/schema/ui.rb
+++ b/lib/r2-oas/schema/ui.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal:true
 
 require 'docker'
-require 'eventmachine'
+require 'em/pure_ruby'
 require 'watir'
 require 'forwardable'
 


### PR DESCRIPTION
### Summary

Fix #168 

### RSpec

```bash
$ /bin/bash devscript/all_support_ruby.sh rspec

===== Rspec for All Support Ruby Result =====
ruby-2.4.4: 0
ruby-2.5.8: 0
ruby-2.6.6: 0
ruby-2.7.1: 0
=============================================
```

### Rubocop

```bash
$ be rubocop
Inspecting 203 files
...........................................................................................................................................................................................................

203 files inspected, no offenses detected
```