### PR TITLE
WARNING: Using `expect { }.not_to raise_error(SpecificErrorClass)` risks false positives

### DIFF
--- a/spec/r2-oas/schema/v3/object/from_files/utils/refs_spec.rb
+++ b/spec/r2-oas/schema/v3/object/from_files/utils/refs_spec.rb
@@ -82,8 +82,8 @@ RSpec.shared_examples 'test accessors when components schema/request_body ref' d
 
   context 'when error not occurs' do
     it do
-      expect { subject.schema_name = 'API_V1_Task_200_GET' }.not_to raise_error(NoMethodError)
-      expect { subject[:schema_name] = 'API_V1_Task_200_GET' }.not_to raise_error(R2OAS::RefInvalidAssignment)
+      expect { subject.schema_name = 'API_V1_Task_200_GET' }.not_to raise_error
+      expect { subject[:schema_name] = 'API_V1_Task_200_GET' }.not_to raise_error
     end
   end
 end

--- a/spec/r2-oas/tasks/main_spec.rb
+++ b/spec/r2-oas/tasks/main_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe 'main_rake' do
         end
 
         it 'should do not occur error' do
-          expect { subject }.not_to raise_error(R2OAS::NoFileExistsError)
+          expect { subject }.not_to raise_error
         end
         it do
           subject


### PR DESCRIPTION
### Summary

Fix #173 

[ref]
https://stackoverflow.com/a/61155092/9434894

### RSpec

```bash
===== Rspec for All Support Ruby Result =====
ruby-2.5.8: 0
ruby-2.6.6: 0
ruby-2.7.1: 0
=============================================
```

### Rubocop

```bash
$ be rubocop
Inspecting 202 files
..........................................................................................................................................................................................................

202 files inspected, no offenses detected
```