### PR TITLE
feat: rename exists? to exist? of FileTest

### DIFF
--- a/lib/r2-oas/configuration.rb
+++ b/lib/r2-oas/configuration.rb
@@ -97,14 +97,14 @@ module R2OAS
     def load_local_tasks
       tasks_path = File.expand_path("#{root_dir_path}/#{local_tasks_dir_name}")
       Dir.glob("#{tasks_path}/**/*.rake").sort.each do |file|
-        load file if FileTest.exists?(file)
+        load file if FileTest.exist?(file)
       end
     end
 
     def load_local_plugins
       plugins_path = File.expand_path("#{root_dir_path}/#{local_plugins_dir_name}")
       Dir.glob("#{plugins_path}/**/*.rb").sort.each do |file|
-        require file if FileTest.exists?(file)
+        require file if FileTest.exist?(file)
       end
     end
 

--- a/lib/r2-oas/configuration/paths_config.rb
+++ b/lib/r2-oas/configuration/paths_config.rb
@@ -24,7 +24,7 @@ module R2OAS
       def many_paths_file_paths
         @many_paths_file_paths ||= File.read(abs_paths_path).split("\n").each_with_object([]) do |relative_path, result|
           abs_path = File.expand_path("#{@schema_save_dir_path}/paths/#{relative_path}")
-          result.push(abs_path) if FileTest.exists?(abs_path) && FileTest.file?(abs_path)
+          result.push(abs_path) if FileTest.exist?(abs_path) && FileTest.file?(abs_path)
         end.uniq.compact.reject(&:empty?)
       end
 

--- a/lib/r2-oas/deploy/client.rb
+++ b/lib/r2-oas/deploy/client.rb
@@ -30,8 +30,8 @@ module R2OAS
 
       def copy_swagger_ui_dist
         docs_path = File.expand_path(Rails.root.join(deploy_dir_path), __FILE__)
-        FileUtils.mkdir_p(docs_path) unless FileTest.exists?(docs_path)
-        FileUtils.mkdir_p(@dist_path) unless FileTest.exists?(@dist_path)
+        FileUtils.mkdir_p(docs_path) unless FileTest.exist?(docs_path)
+        FileUtils.mkdir_p(@dist_path) unless FileTest.exist?(@dist_path)
         FileUtils.cp_r(@dist_path, docs_path)
       end
 

--- a/lib/r2-oas/helpers/file_helper.rb
+++ b/lib/r2-oas/helpers/file_helper.rb
@@ -35,14 +35,14 @@ module R2OAS
   module Helpers
     module FileHelper
       def write_file_or_skip(file_path, data, silent = false)
-        unless FileTest.exists?(file_path)
+        unless FileTest.exist?(file_path)
           File.write(file_path, data)
           puts "#{space}#{bold('create')}\t#{relative(file_path)}" unless silent
         end
       end
 
       def mkdir_p_dir_or_skip(dir_path, silent = false)
-        unless FileTest.exists?(dir_path)
+        unless FileTest.exist?(dir_path)
           FileUtils.mkdir_p(dir_path)
           puts "#{space}#{bold('create')}\t#{relative(dir_path)}" unless silent
         end

--- a/lib/r2-oas/schema/v3/analyzer/base_analyzer.rb
+++ b/lib/r2-oas/schema/v3/analyzer/base_analyzer.rb
@@ -43,7 +43,7 @@ module R2OAS
         end
 
         def create_after_schema_data_when_not_specify_path
-          if FileTest.exists?(doc_save_file_path)
+          if FileTest.exist?(doc_save_file_path)
             YAML.load_file(doc_save_file_path)
           else
             raise NoFileExistsError, "Do not exists file: #{doc_save_file_path}"

--- a/lib/r2-oas/schema/v3/generator/base_generator.rb
+++ b/lib/r2-oas/schema/v3/generator/base_generator.rb
@@ -102,7 +102,7 @@ module R2OAS
         end
 
         def exists_cache?
-          FileTest.exists?(abs_cache_docs_path)
+          FileTest.exist?(abs_cache_docs_path)
         end
 
         def abs_cache_docs_path

--- a/lib/r2-oas/schema/v3/manager/file/base_file_manager.rb
+++ b/lib/r2-oas/schema/v3/manager/file/base_file_manager.rb
@@ -19,12 +19,12 @@ module R2OAS
         end
 
         def delete
-          File.delete(save_file_path) if FileTest.exists?(save_file_path)
+          File.delete(save_file_path) if FileTest.exist?(save_file_path)
         end
 
         def save(data)
           abs_dir = File.dirname(save_file_path)
-          FileUtils.mkdir_p(abs_dir) unless FileTest.exists?(abs_dir)
+          FileUtils.mkdir_p(abs_dir) unless FileTest.exist?(abs_dir)
           File.write(save_file_path, data)
         end
 
@@ -47,7 +47,7 @@ module R2OAS
         def load_data
           case @ext_name
           when :yml
-            if FileTest.exists?(save_file_path)
+            if FileTest.exist?(save_file_path)
               YAML.load_file(save_file_path)
             else
               {}

--- a/lib/r2-oas/tasks/main.rake
+++ b/lib/r2-oas/tasks/main.rake
@@ -41,7 +41,7 @@ namespace :routes do
     task build: [:common] do
       start do
         output_dir_path = File.expand_path(R2OAS.output_dir_path)
-        FileUtils.mkdir_p(output_dir_path) unless FileTest.exists?(output_dir_path)
+        FileUtils.mkdir_p(output_dir_path) unless FileTest.exist?(output_dir_path)
 
         is_overrirde_src = override_src.eql? 'true'
         use_plugin = skip_plugin.eql? 'false'
@@ -124,7 +124,7 @@ namespace :routes do
         end
 
         output_dir_path = File.expand_path(R2OAS.output_dir_path)
-        FileUtils.mkdir_p(output_dir_path) unless FileTest.exists?(output_dir_path)
+        FileUtils.mkdir_p(output_dir_path) unless FileTest.exist?(output_dir_path)
 
         builder_options = { unit_paths_file_path: unit_paths_file_path, use_plugin: true, output: true }
         builder = R2OAS::Schema::Builder.new(builder_options)

--- a/spec/r2-oas/configuration/paths_config_spec.rb
+++ b/spec/r2-oas/configuration/paths_config_spec.rb
@@ -110,6 +110,6 @@ RSpec.describe R2OAS::Configuration::PathsConfig do
   end
 
   describe '#create_dot_paths' do
-    it { expect { config.create_dot_paths }.to change { FileTest.exists?("#{root_dir_path}/.paths") }.from(false).to(true) }
+    it { expect { config.create_dot_paths }.to change { FileTest.exist?("#{root_dir_path}/.paths") }.from(false).to(true) }
   end
 end

--- a/spec/r2-oas/deploy/client_spec.rb
+++ b/spec/r2-oas/deploy/client_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe R2OAS::Deploy::Client do
     end
 
     it do
-      expect(FileTest.exists?(deploy_dir_path)).to eq true
-      expect(FileTest.exists?("#{deploy_dir_path}/index.html")).to eq true
-      expect(FileTest.exists?("#{deploy_dir_path}/dist")).to eq true
+      expect(FileTest.exist?(deploy_dir_path)).to eq true
+      expect(FileTest.exist?("#{deploy_dir_path}/index.html")).to eq true
+      expect(FileTest.exist?("#{deploy_dir_path}/dist")).to eq true
     end
   end
 end

--- a/spec/r2-oas/schema/v3/analyzer_spec.rb
+++ b/spec/r2-oas/schema/v3/analyzer_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe R2OAS::Schema::V3::Analyzer do
 
   shared_examples_for 'Generated file verification test' do |result|
     it 'should generate docs' do
-      expect(FileTest.exists?(components_schemas_path)).to eq result
-      expect(FileTest.exists?(components_request_bodies_path)).to eq result
-      expect(FileTest.exists?(paths_path)).to eq result
-      expect(FileTest.exists?(external_docs_path)).to eq result
-      expect(FileTest.exists?(info_path)).to eq result
-      expect(FileTest.exists?(openapi_path)).to eq result
-      expect(FileTest.exists?(servers_path)).to eq result
-      expect(FileTest.exists?(tags_path)).to eq result
+      expect(FileTest.exist?(components_schemas_path)).to eq result
+      expect(FileTest.exist?(components_request_bodies_path)).to eq result
+      expect(FileTest.exist?(paths_path)).to eq result
+      expect(FileTest.exist?(external_docs_path)).to eq result
+      expect(FileTest.exist?(info_path)).to eq result
+      expect(FileTest.exist?(openapi_path)).to eq result
+      expect(FileTest.exist?(servers_path)).to eq result
+      expect(FileTest.exist?(tags_path)).to eq result
     end
   end
 
@@ -75,7 +75,7 @@ RSpec.describe R2OAS::Schema::V3::Analyzer do
 
       it_behaves_like 'Generated file verification test', true
       it 'The file obtained by editing exists' do
-        expect(FileTest.exists?("#{components_schemas_path}/task/edit/p1/get/200.yml")).to eq true
+        expect(FileTest.exist?("#{components_schemas_path}/task/edit/p1/get/200.yml")).to eq true
       end
     end
   end

--- a/spec/r2-oas/schema/v3/builder_spec.rb
+++ b/spec/r2-oas/schema/v3/builder_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe R2OAS::Schema::V3::Builder do
 
   shared_examples_for 'Generated file verification test' do |result|
     it 'should build docs' do
-      expect(FileTest.exists?(components_schemas_path)).to eq result
-      expect(FileTest.exists?(components_request_bodies_path)).to eq result
-      expect(FileTest.exists?(paths_path)).to eq result
-      expect(FileTest.exists?(external_docs_path)).to eq result
-      expect(FileTest.exists?(info_path)).to eq result
-      expect(FileTest.exists?(openapi_path)).to eq result
-      expect(FileTest.exists?(servers_path)).to eq result
-      expect(FileTest.exists?(tags_path)).to eq result
+      expect(FileTest.exist?(components_schemas_path)).to eq result
+      expect(FileTest.exist?(components_request_bodies_path)).to eq result
+      expect(FileTest.exist?(paths_path)).to eq result
+      expect(FileTest.exist?(external_docs_path)).to eq result
+      expect(FileTest.exist?(info_path)).to eq result
+      expect(FileTest.exist?(openapi_path)).to eq result
+      expect(FileTest.exist?(servers_path)).to eq result
+      expect(FileTest.exist?(tags_path)).to eq result
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe R2OAS::Schema::V3::Builder do
       end
 
       it_behaves_like 'Generated file verification test', true
-      it { expect(FileTest.exists?(doc_save_file_path)).to eq true }
+      it { expect(FileTest.exist?(doc_save_file_path)).to eq true }
     end
 
     context 'when output is true' do
@@ -48,7 +48,7 @@ RSpec.describe R2OAS::Schema::V3::Builder do
         builder.build_docs
       end
 
-      it { expect(FileTest.exists?(output_path)).to eq true }
+      it { expect(FileTest.exist?(output_path)).to eq true }
     end
   end
 

--- a/spec/r2-oas/schema/v3/cleaner_spec.rb
+++ b/spec/r2-oas/schema/v3/cleaner_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe R2OAS::Schema::V3::Cleaner do
     end
 
     it 'remove unreferenced components files(except securitySchemes files)' do
-      expect(FileTest.exists?("#{components_schemas_path}/dummy.yml")).to eq false
-      expect(FileTest.exists?("#{components_securitySchemes_path}/my_oauth.yml")).to eq true
+      expect(FileTest.exist?("#{components_schemas_path}/dummy.yml")).to eq false
+      expect(FileTest.exist?("#{components_securitySchemes_path}/my_oauth.yml")).to eq true
     end
   end
 end

--- a/spec/r2-oas/schema/v3/generator_spec.rb
+++ b/spec/r2-oas/schema/v3/generator_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe R2OAS::Schema::V3::Generator do
 
   shared_examples_for 'Generated file verification test' do |result|
     it 'should generate docs' do
-      expect(FileTest.exists?(components_schemas_path)).to eq result
-      expect(FileTest.exists?(components_request_bodies_path)).to eq result
-      expect(FileTest.exists?(paths_path)).to eq result
-      expect(FileTest.exists?(external_docs_path)).to eq result
-      expect(FileTest.exists?(info_path)).to eq result
-      expect(FileTest.exists?(openapi_path)).to eq result
-      expect(FileTest.exists?(servers_path)).to eq result
-      expect(FileTest.exists?(tags_path)).to eq result
+      expect(FileTest.exist?(components_schemas_path)).to eq result
+      expect(FileTest.exist?(components_request_bodies_path)).to eq result
+      expect(FileTest.exist?(paths_path)).to eq result
+      expect(FileTest.exist?(external_docs_path)).to eq result
+      expect(FileTest.exist?(info_path)).to eq result
+      expect(FileTest.exist?(openapi_path)).to eq result
+      expect(FileTest.exist?(servers_path)).to eq result
+      expect(FileTest.exist?(tags_path)).to eq result
     end
   end
 
@@ -37,7 +37,7 @@ RSpec.describe R2OAS::Schema::V3::Generator do
       end
 
       it_behaves_like 'Generated file verification test', true
-      it { expect(FileTest.exists?(doc_save_file_path)).to eq false }
+      it { expect(FileTest.exist?(doc_save_file_path)).to eq false }
     end
   end
 end

--- a/spec/r2-oas/schema/v3/manager/file/base_file_manager_spec.rb
+++ b/spec/r2-oas/schema/v3/manager/file/base_file_manager_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe R2OAS::Schema::V3::BaseFileManager do
     end
 
     it do
-      expect { manager.delete }.to change { FileTest.exists?("#{components_schemas_path}/dummy.yml") }.from(true).to(false)
+      expect { manager.delete }.to change { FileTest.exist?("#{components_schemas_path}/dummy.yml") }.from(true).to(false)
     end
   end
 

--- a/spec/r2-oas/tasks/main_spec.rb
+++ b/spec/r2-oas/tasks/main_spec.rb
@@ -16,14 +16,14 @@ RSpec.describe 'main_rake' do
 
   shared_examples_for 'Generated file verification test' do |result|
     it 'should generate docs' do
-      expect(FileTest.exists?(components_schemas_path)).to eq result
-      expect(FileTest.exists?(components_request_bodies_path)).to eq result
-      expect(FileTest.exists?(paths_path)).to eq result
-      expect(FileTest.exists?(external_docs_path)).to eq result
-      expect(FileTest.exists?(info_path)).to eq result
-      expect(FileTest.exists?(openapi_path)).to eq result
-      expect(FileTest.exists?(servers_path)).to eq result
-      expect(FileTest.exists?(tags_path)).to eq result
+      expect(FileTest.exist?(components_schemas_path)).to eq result
+      expect(FileTest.exist?(components_request_bodies_path)).to eq result
+      expect(FileTest.exist?(paths_path)).to eq result
+      expect(FileTest.exist?(external_docs_path)).to eq result
+      expect(FileTest.exist?(info_path)).to eq result
+      expect(FileTest.exist?(openapi_path)).to eq result
+      expect(FileTest.exist?(servers_path)).to eq result
+      expect(FileTest.exist?(tags_path)).to eq result
     end
   end
 
@@ -35,14 +35,14 @@ RSpec.describe 'main_rake' do
     end
 
     it do
-      expect(FileTest.exists?(plugins_path)).to eq true
-      expect(FileTest.exists?("#{plugins_path}/helpers")).to eq true
-      expect(FileTest.exists?(tasks_path)).to eq true
-      expect(FileTest.exists?(dot_paths_path)).to eq true
-      expect(FileTest.exists?("#{plugins_path}/.gitkeep")).to eq true
-      expect(FileTest.exists?("#{plugins_path}/helpers/.gitkeep")).to eq true
-      expect(FileTest.exists?("#{tasks_path}/.gitkeep")).to eq true
-      expect(FileTest.exists?("#{tasks_path}/helpers/.gitkeep")).to eq true
+      expect(FileTest.exist?(plugins_path)).to eq true
+      expect(FileTest.exist?("#{plugins_path}/helpers")).to eq true
+      expect(FileTest.exist?(tasks_path)).to eq true
+      expect(FileTest.exist?(dot_paths_path)).to eq true
+      expect(FileTest.exist?("#{plugins_path}/.gitkeep")).to eq true
+      expect(FileTest.exist?("#{plugins_path}/helpers/.gitkeep")).to eq true
+      expect(FileTest.exist?("#{tasks_path}/.gitkeep")).to eq true
+      expect(FileTest.exist?("#{tasks_path}/helpers/.gitkeep")).to eq true
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe 'main_rake' do
       end
 
       it_behaves_like 'Generated file verification test', true
-      it { expect(FileTest.exists?(doc_save_file_path)).to eq false }
+      it { expect(FileTest.exist?(doc_save_file_path)).to eq false }
     end
 
     context 'when oas_docs exists already' do
@@ -80,7 +80,7 @@ RSpec.describe 'main_rake' do
         end
         it do
           subject
-          expect(FileTest.exists?(relative_cache_docs_path)).to eq true
+          expect(FileTest.exist?(relative_cache_docs_path)).to eq true
         end
       end
     end
@@ -100,21 +100,21 @@ RSpec.describe 'main_rake' do
       let(:ext_name) { :json }
 
       it_behaves_like 'Generated file verification test', true
-      it { expect(FileTest.exists?(doc_save_file_path)).to eq true }
+      it { expect(FileTest.exist?(doc_save_file_path)).to eq true }
     end
 
     context 'when ext_name is :yml' do
       let(:ext_name) { :yml }
 
       it_behaves_like 'Generated file verification test', true
-      it { expect(FileTest.exists?(doc_save_file_path)).to eq true }
+      it { expect(FileTest.exist?(doc_save_file_path)).to eq true }
     end
 
     context 'when ext_name is :yaml' do
       let(:ext_name) { :yml }
 
       it_behaves_like 'Generated file verification test', true
-      it { expect(FileTest.exists?(doc_save_file_path)).to eq true }
+      it { expect(FileTest.exist?(doc_save_file_path)).to eq true }
     end
   end
 
@@ -126,8 +126,8 @@ RSpec.describe 'main_rake' do
       subject
     end
 
-    it { expect(FileTest.exists?(doc_save_file_path)).to eq false }
-    it { expect(FileTest.exists?(output_path)).to eq true }
+    it { expect(FileTest.exist?(doc_save_file_path)).to eq false }
+    it { expect(FileTest.exist?(output_path)).to eq true }
   end
 
   describe 'routes:oas:clean' do
@@ -143,9 +143,9 @@ RSpec.describe 'main_rake' do
     end
 
     it do
-      expect(FileTest.exists?("#{components_schemas_path}/dummy.yml")).to eq false
-      expect(FileTest.exists?("#{components_request_bodies_path}/dummy.yml")).to eq false
-      expect(FileTest.exists?("#{components_securitySchemes_path}/my_oauth.yml")).to eq true
+      expect(FileTest.exist?("#{components_schemas_path}/dummy.yml")).to eq false
+      expect(FileTest.exist?("#{components_request_bodies_path}/dummy.yml")).to eq false
+      expect(FileTest.exist?("#{components_securitySchemes_path}/my_oauth.yml")).to eq true
     end
   end
 
@@ -163,9 +163,9 @@ RSpec.describe 'main_rake' do
     end
 
     it do
-      expect(FileTest.exists?(deploy_dir_path.to_s)).to eq true
-      expect(FileTest.exists?("#{deploy_dir_path}/#{doc_save_file_name}")).to eq true
-      expect(FileTest.exists?(output_path)).to eq true
+      expect(FileTest.exist?(deploy_dir_path.to_s)).to eq true
+      expect(FileTest.exist?("#{deploy_dir_path}/#{doc_save_file_name}")).to eq true
+      expect(FileTest.exist?(output_path)).to eq true
     end
   end
 end

--- a/spec/support/helpers/create_helper.rb
+++ b/spec/support/helpers/create_helper.rb
@@ -29,25 +29,25 @@ module CreateHelper
   end
 
   def create_components_securitySchemes_file
-    FileUtils.mkdir_p(components_securitySchemes_path) unless FileTest.exists?(components_securitySchemes_path)
+    FileUtils.mkdir_p(components_securitySchemes_path) unless FileTest.exist?(components_securitySchemes_path)
     File.write("#{components_securitySchemes_path}/my_oauth.yml", yaml_fixture('src/components/securitySchemes/my_oauth.yml'))
   end
 
   def create_paths_file(file_name = 'dummy.yml', yaml = "---\n")
     dirname = File.dirname("#{paths_path}/#{file_name}")
-    FileUtils.mkdir_p(dirname) unless FileTest.exists?(dirname)
+    FileUtils.mkdir_p(dirname) unless FileTest.exist?(dirname)
     File.write("#{paths_path}/#{file_name}", yaml)
   end
 
   def create_components_schemas_file(file_name = 'dummy.yml', yaml = "---\n")
     dirname = File.dirname("#{components_schemas_path}/#{file_name}")
-    FileUtils.mkdir_p(dirname) unless FileTest.exists?(dirname)
+    FileUtils.mkdir_p(dirname) unless FileTest.exist?(dirname)
     File.write("#{components_schemas_path}/#{file_name}", yaml)
   end
 
   def create_components_request_bodies_file(file_name = 'dummy.yml', yaml = "---\n")
     dirname = File.dirname("#{components_request_bodies_path}/#{file_name}")
-    FileUtils.mkdir_p(dirname) unless FileTest.exists?(dirname)
+    FileUtils.mkdir_p(dirname) unless FileTest.exist?(dirname)
     File.write("#{components_request_bodies_path}/#{file_name}", yaml)
   end
 
@@ -68,7 +68,7 @@ module CreateHelper
   end
 
   def copy_tasks
-    FileUtils.mkdir Rails.root.join(root_dir_path) unless FileTest.exists?(Rails.root.join(root_dir_path))
+    FileUtils.mkdir Rails.root.join(root_dir_path) unless FileTest.exist?(Rails.root.join(root_dir_path))
 
     local_tasks_path = Rails.root.join('tasks')
     FileUtils.cp_r(local_tasks_path, tasks_path)
@@ -81,6 +81,6 @@ module CreateHelper
   end
 
   def create_output_dir
-    FileUtils.mkdir_p(output_dir_path) unless FileTest.exists?(output_dir_path)
+    FileUtils.mkdir_p(output_dir_path) unless FileTest.exist?(output_dir_path)
   end
 end


### PR DESCRIPTION
In Ruby 3, function `.exists?` was rename to `exist?` in `FileTest`.

`FileTest.exist?` works in Ruby 2 and 3